### PR TITLE
Type Inference in Context

### DIFF
--- a/facet.cabal
+++ b/facet.cabal
@@ -145,6 +145,7 @@ test-suite test
   hs-source-dirs: test
   other-modules:
     Facet.Carrier.Parser.Church.Test
+    Facet.Core.Test
     Facet.Source.Test
   main-is: Test.hs
   build-depends:

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -55,14 +55,14 @@ infixl 5 |>
 level :: Context -> Level
 level (Context c) = Level (length c)
 
--- FIXME: skip Ty entries
 (!) :: HasCallStack => Context -> Index -> Entry
 Context es' ! Index i' = withFrozenCallStack $ go es' i'
   where
-  go (es S.:> e) i
-    | i == 0       = e
-    | otherwise    = go es (i - 1)
-  go _           _ = error $ "Facet.Context.!: index (" <> show i' <> ") out of bounds (" <> show (length es') <> ")"
+  go (es S.:> e@Tm{}) i
+    | i == 0            = e
+    | otherwise         = go es (i - 1)
+  go (es S.:> _)      i = go es i
+  go _                _ = error $ "Facet.Context.!: index (" <> show i' <> ") out of bounds (" <> show (length es') <> ")"
 
 lookupIndex :: Name -> Context -> Maybe (Index, Type)
 lookupIndex n = go (Index 0) . elems

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -51,6 +51,7 @@ Context as |> a = Context (as S.:> a)
 
 infixl 5 |>
 
+-- FIXME: don’t count Ty entries.
 level :: Context -> Level
 level (Context c) = Level (length c)
 

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -51,9 +51,12 @@ Context as |> a = Context (as S.:> a)
 
 infixl 5 |>
 
--- FIXME: don’t count Ty entries.
 level :: Context -> Level
-level (Context c) = Level (length c)
+level (Context es) = go 0 es
+  where
+  go n S.Nil          = n
+  go n (es S.:> Tm{}) = go (n + 1) es
+  go n (es S.:> Ty{}) = go  n      es
 
 (!) :: HasCallStack => Context -> Index -> Entry
 Context es' ! Index i' = withFrozenCallStack $ go es' i'

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -17,6 +17,7 @@ module Facet.Context
 ) where
 
 import           Data.Foldable (foldl')
+import           Data.Maybe (fromMaybe)
 import           Facet.Core
 import           Facet.Name
 import qualified Facet.Stack as S
@@ -79,8 +80,12 @@ lookupIndex n = go (Index 0) . elems
 
 
 -- | Construct an environment suitable for evaluation from a 'Context'.
-toEnv :: Context -> S.Stack (Maybe Value)
-toEnv = fmap entryDef . elems
+toEnv :: Context -> S.Stack Value
+toEnv = go 0 . elems
+  where
+  go _ S.Nil              = S.Nil
+  go i (es S.:> Tm _   _) = go (succ i) es S.:> free (indexToLevel (Level (length es)) i)
+  go i (es S.:> Ty m d _) = go       i  es S.:> fromMaybe (metavar m) d
 
 
 type Suffix = [Meta :=: Maybe Type ::: Type]

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -57,7 +57,12 @@ level (Context c) = Level (length c)
 
 -- FIXME: skip Ty entries
 (!) :: HasCallStack => Context -> Index -> Entry
-c ! i = elems c S.! getIndex i
+Context es' ! Index i' = withFrozenCallStack $ go es' i'
+  where
+  go (es S.:> e) i
+    | i == 0       = e
+    | otherwise    = go es (i - 1)
+  go _           _ = error $ "Facet.Context.!: index (" <> show i' <> ") out of bounds (" <> show (length es') <> ")"
 
 lookupIndex :: Name -> Context -> Maybe (Index, Type)
 lookupIndex n = go (Index 0) . elems

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -7,7 +7,6 @@ module Facet.Context
 , empty
 , (|>)
 , level
-, (!?)
 , (!)
 , lookupIndex
 , Suffix
@@ -54,10 +53,6 @@ infixl 5 |>
 
 level :: Context -> Level
 level (Context c) = Level (length c)
-
--- FIXME: skip Ty entries
-(!?) :: Context -> Index -> Maybe Entry
-c !? i = elems c S.!? getIndex i
 
 -- FIXME: skip Ty entries
 (!) :: HasCallStack => Context -> Index -> Entry

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -28,6 +28,8 @@ newtype Context = Context { elems :: S.Stack Entry }
 
 data Entry
   -- FIXME: constructor names are unclear; Tm is typing, Ty is meta.
+  -- FIXME: record implicitness in the context.
+  -- FIXME: record sort in the context.
   = Tm Name Type
   | Ty Meta (Maybe Type) Type
 

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -84,8 +84,8 @@ type Suffix = [Meta :=: Maybe Type ::: Type]
 
 infixl 5 <><
 
-restore :: Applicative m => a -> m (a, Maybe Suffix)
-restore = pure . (,Nothing)
+restore :: Applicative m => m (Maybe Suffix)
+restore = pure Nothing
 
-replace :: Applicative m => Suffix -> a -> m (a, Maybe Suffix)
-replace a = pure . (,Just a)
+replace :: Applicative m => Suffix -> m (Maybe Suffix)
+replace a = pure (Just a)

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -29,21 +29,20 @@ import           Prelude hiding (lookup)
 newtype Context = Context { elems :: S.Stack Entry }
 
 data Entry
-  -- FIXME: constructor names are unclear; Tm is typing, Ty is meta.
   -- FIXME: record implicitness in the context.
   -- FIXME: record sort in the context.
-  = Tm Name Type
-  | Ty Meta (Maybe Type) Type
+  = Rigid Name Type
+  | Flex Meta (Maybe Type) Type
 
 entryDef :: Entry -> Maybe Type
 entryDef = \case
-  Tm _   _ -> Nothing
-  Ty _ v _ -> v
+  Rigid _   _ -> Nothing
+  Flex  _ v _ -> v
 
 entryType :: Entry -> Type
 entryType = \case
-  Tm _   t -> t
-  Ty _ _ t -> t
+  Rigid _   t -> t
+  Flex  _ _ t -> t
 
 
 empty :: Context
@@ -57,27 +56,27 @@ infixl 5 |>
 level :: Context -> Level
 level (Context es) = go 0 es
   where
-  go n S.Nil          = n
-  go n (es S.:> Tm{}) = go (n + 1) es
-  go n (es S.:> Ty{}) = go  n      es
+  go n S.Nil             = n
+  go n (es S.:> Rigid{}) = go (n + 1) es
+  go n (es S.:> Flex{})  = go  n      es
 
 (!) :: HasCallStack => Context -> Index -> Entry
 Context es' ! Index i' = withFrozenCallStack $ go es' i'
   where
-  go (es S.:> e@Tm{}) i
-    | i == 0            = e
-    | otherwise         = go es (i - 1)
-  go (es S.:> _)      i = go es i
-  go _                _ = error $ "Facet.Context.!: index (" <> show i' <> ") out of bounds (" <> show (length es') <> ")"
+  go (es S.:> e@Rigid{}) i
+    | i == 0               = e
+    | otherwise            = go es (i - 1)
+  go (es S.:> _)         i = go es i
+  go _                   _ = error $ "Facet.Context.!: index (" <> show i' <> ") out of bounds (" <> show (length es') <> ")"
 
 lookupIndex :: Name -> Context -> Maybe (Index, Type)
 lookupIndex n = go (Index 0) . elems
   where
-  go _ S.Nil          = Nothing
-  go i (cs S.:> Tm n' t)
-    | n == n'         = Just (i, t)
-    | otherwise       = go (succ i) cs
-  go i (cs S.:> Ty{}) = go i cs
+  go _ S.Nil            = Nothing
+  go i (cs S.:> Rigid n' t)
+    | n == n'           = Just (i, t)
+    | otherwise         = go (succ i) cs
+  go i (cs S.:> Flex{}) = go i cs
 
 
 -- | Construct an environment suitable for evaluation from a 'Context'.
@@ -86,19 +85,19 @@ toEnv c = (locals 0 (elems c), metas (elems c))
   where
   d = level c
   locals i = \case
-    S.Nil            -> S.Nil
-    bs S.:> Tm _   _ -> locals (succ i) bs S.:> free (indexToLevel d i)
-    bs S.:> Ty _ _ _ -> locals i bs
+    S.Nil               -> S.Nil
+    bs S.:> Rigid _   _ -> locals (succ i) bs S.:> free (indexToLevel d i)
+    bs S.:> Flex  _ _ _ -> locals i bs
   metas = \case
-    S.Nil            -> mempty
-    bs S.:> Tm _   _ -> metas bs
-    bs S.:> Ty m v _ -> IntMap.insert (getMeta m) (fromMaybe (metavar m) v) (metas bs)
+    S.Nil               -> mempty
+    bs S.:> Rigid _   _ -> metas bs
+    bs S.:> Flex  m v _ -> IntMap.insert (getMeta m) (fromMaybe (metavar m) v) (metas bs)
 
 
 type Suffix = [Meta :=: Maybe Type ::: Type]
 
 (<><) :: Context -> Suffix -> Context
-(<><) = foldl' (\ gamma (n :=: v ::: _T) -> gamma |> Ty n v _T)
+(<><) = foldl' (\ gamma (n :=: v ::: _T) -> gamma |> Flex n v _T)
 
 infixl 5 <><
 

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -9,7 +9,6 @@ module Facet.Context
 , level
 , (!)
 , lookupIndex
-, toEnv
 , Suffix
 , (<><)
 , restore
@@ -17,8 +16,6 @@ module Facet.Context
 ) where
 
 import           Data.Foldable (foldl')
-import           Data.Maybe (fromMaybe)
-import           Facet.Core
 import           Facet.Name
 import qualified Facet.Stack as S
 import           Facet.Syntax
@@ -77,15 +74,6 @@ lookupIndex n = go (Index 0) . elems
     | n == n'         = Just (i, t)
     | otherwise       = go (succ i) cs
   go i (cs S.:> Ty{}) = go i cs
-
-
--- | Construct an environment suitable for evaluation from a 'Context'.
-toEnv :: Context Type -> S.Stack Type
-toEnv = go 0 . elems
-  where
-  go _ S.Nil              = S.Nil
-  go i (es S.:> Tm _   _) = go (succ i) es S.:> free (indexToLevel (Level (length es)) i)
-  go i (es S.:> Ty m d _) = go       i  es S.:> fromMaybe (metavar m) d
 
 
 type Suffix a = [Meta :=: Maybe a ::: a]

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -9,6 +9,7 @@ module Facet.Context
 , level
 , (!)
 , lookupIndex
+, toEnv
 , Suffix
 , (<><)
 , restore
@@ -75,6 +76,11 @@ lookupIndex n = go (Index 0) . elems
     | n == n'         = Just (i, t)
     | otherwise       = go (succ i) cs
   go i (cs S.:> Ty{}) = go i cs
+
+
+-- | Construct an environment suitable for evaluation from a 'Context'.
+toEnv :: Context -> S.Stack (Maybe Value)
+toEnv = fmap entryDef . elems
 
 
 type Suffix = [Meta :=: Maybe Type ::: Type]

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -159,7 +159,7 @@ instantiateClause d (Clause p b) = b <$> bindPattern d p
 
 
 data Binding a = Binding
-  { pl    :: Icit
+  { icit  :: Icit
   , name  :: Maybe Name
   , delta :: Maybe [a]
   , type' :: a

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -87,14 +87,14 @@ data Value
   = KType
   | KInterface
   | TSusp Comp
-  | ELam Pl [Clause]
+  | ELam Icit [Clause]
   -- | Neutral terms are an unreduced head followed by a stack of eliminators.
-  | VNe (Var Level :$ (Pl, Value))
+  | VNe (Var Level :$ (Icit, Value))
   | ECon (Q Name :$ Expr)
   | TString
   | EString Text
   -- | Effect operation and its parameters.
-  | EOp (Q Name :$ (Pl, Expr))
+  | EOp (Q Name :$ (Icit, Expr))
 
 type Type = Value
 type Expr = Value
@@ -132,7 +132,7 @@ unBind' :: Alternative m => (Level, Comp) -> m (Binding Value, (Level, Comp))
 unBind' (d, v) = fmap (\ _B -> (succ d, _B (free d))) <$> unBind v
 
 
-unLam :: Alternative m => Value -> m (Pl, [Clause])
+unLam :: Alternative m => Value -> m (Icit, [Clause])
 unLam = \case{ ELam n b -> pure (n, b) ; _ -> empty }
 
 
@@ -159,7 +159,7 @@ instantiateClause d (Clause p b) = b <$> bindPattern d p
 
 
 data Binding a = Binding
-  { pl    :: Pl
+  { pl    :: Icit
   , name  :: Maybe Name
   , delta :: Maybe [a]
   , type' :: a
@@ -238,7 +238,7 @@ occursIn p = go (Level 0) -- FIXME: this should probably be doing something more
 
 -- Elimination
 
-($$) :: HasCallStack => Value -> (Pl, Value) -> Value
+($$) :: HasCallStack => Value -> (Icit, Value) -> Value
 VNe (h :$ es) $$ a = VNe (h :$ (es :> a))
 EOp (q :$ es) $$ a = EOp (q :$ (es :> a))
 TSusp t       $$ a
@@ -250,7 +250,7 @@ TSusp t       $$ a
 ELam _ b      $$ a = case' (snd a) b
 _             $$ _ = error "can’t apply non-neutral/forall type"
 
-($$*) :: (HasCallStack, Foldable t) => Value -> t (Pl, Value) -> Value
+($$*) :: (HasCallStack, Foldable t) => Value -> t (Icit, Value) -> Value
 ($$*) = foldl' ($$)
 
 infixl 9 $$, $$*
@@ -440,8 +440,8 @@ data Quote
   | QKType
   | QKInterface
   | QTSusp QComp
-  | QELam Pl [(Pattern Name, Quote)]
-  | QApp Quote (Pl, Quote)
+  | QELam Icit [(Pattern Name, Quote)]
+  | QApp Quote (Icit, Quote)
   | QECon (Q Name :$ Quote)
   | QTString
   | QEString Text

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -15,6 +15,7 @@ module Facet.Core
 , Clause(..)
 , instantiateClause
 , Binding(..)
+, icit_
   -- ** Variables
 , Var(..)
 , unVar
@@ -165,6 +166,9 @@ data Binding a = Binding
   , type' :: a
   }
   deriving (Foldable, Functor, Traversable)
+
+icit_ :: Lens' (Binding a) Icit
+icit_ = lens icit (\ b icit -> b{ icit })
 
 
 -- Variables

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -118,7 +118,7 @@ data Sig a = Sig
   { effectVar  :: Maybe a
   , interfaces :: [a]
   }
-  deriving (Foldable, Functor, Traversable)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 effectVar_ :: Lens' (Sig a) (Maybe a)
 effectVar_ = lens effectVar (\ s effectVar -> s{ effectVar })
@@ -142,7 +142,7 @@ data Binding a = Binding
   , delta :: Maybe [a]
   , type' :: a
   }
-  deriving (Foldable, Functor, Traversable)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 icit_ :: Lens' (Binding a) Icit
 icit_ = lens icit (\ b icit -> b{ icit })
@@ -157,7 +157,7 @@ data Var a
   = Global (Q Name) -- ^ Global variables, considered equal by 'QName'.
   | Free a
   | Metavar Meta
-  deriving (Foldable, Functor, Traversable)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 unVar :: (Q Name -> b) -> (a -> b) -> (Meta -> b) -> Var a -> b
 unVar f g h = \case
@@ -274,7 +274,7 @@ data Pattern a
   = PVar a
   | PCon (Q Name :$ Pattern a)
   | PEff (Q Name) (Stack (Pattern a)) a
-  deriving (Foldable, Functor, Traversable)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 fill :: Traversable t => (b -> (b, c)) -> b -> t a -> (b, t c)
 fill f = mapAccumL (const . f)
@@ -381,8 +381,10 @@ data Quote
   | QTString
   | QEString Text
   | QEOp (Q Name)
+  deriving (Eq, Ord, Show)
 
 data QComp = QComp [Binding Quote] (Sig Quote) Quote
+  deriving (Eq, Ord, Show)
 
 quote :: Level -> Value -> Quote
 quote d = \case

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -159,24 +159,6 @@ data Var a
   | Metavar Meta
   deriving (Foldable, Functor, Traversable)
 
-instance Eq a => Eq (Var a) where
-  (==) = curry $ \case
-    (Global  q1, Global  q2) -> q1 == q2
-    (Global  _,  _)          -> False
-    (Free    l1, Free    l2) -> l1 == l2
-    (Free    _,  _)          -> False
-    (Metavar m1, Metavar m2) -> m1 == m2
-    (Metavar _,  _)          -> False
-
-instance Ord a => Ord (Var a) where
-  compare = curry $ \case
-    (Global  q1, Global  q2) -> q1 `compare` q2
-    (Global  _,  _)          -> LT
-    (Free    l1, Free    l2) -> l1 `compare` l2
-    (Free    _,  _)          -> LT
-    (Metavar m1, Metavar m2) -> m1 `compare` m2
-    (Metavar _,  _)          -> LT
-
 unVar :: (Q Name -> b) -> (a -> b) -> (Meta -> b) -> Var a -> b
 unVar f g h = \case
   Global  n -> f n

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -66,6 +66,7 @@ import           Control.Lens (Lens', coerced, lens)
 import           Control.Monad (guard)
 import           Data.Foldable (asum, foldl', toList)
 import qualified Data.Map as Map
+import           Data.Maybe (fromMaybe)
 import           Data.Semialign
 import           Data.Text (Text)
 import           Data.Traversable (mapAccumL)

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -474,18 +474,18 @@ quoteComp d c = go d c QComp
     TForAll t b -> \ k -> go (succ d) (b (free d)) $ \ b s t' -> k ((quote d <$> t):b) s t'
     TRet s t    -> \ k -> k [] (quote d <$> s) (quote d t)
 
-eval :: HasCallStack => Stack (Maybe Value) -> Quote -> Value
+eval :: HasCallStack => Stack Value -> Quote -> Value
 eval env = \case
-  QVar v          -> unVar global (\ i -> fromMaybe (free (indexToLevel (Level (length env)) i)) (env ! getIndex i)) metavar v
+  QVar v          -> unVar global ((env !) . getIndex) metavar v
   QKType          -> KType
   QKInterface     -> KInterface
   QTSusp c        -> TSusp $ evalComp env c
-  QELam p cs      -> ELam p $ map (\ (p, b) -> Clause p (\ p -> eval (foldl' (\ env v -> env :> Just v) env p) b)) cs
+  QELam p cs      -> ELam p $ map (\ (p, b) -> Clause p (\ p -> eval (foldl' (:>) env p) b)) cs
   QApp f a        -> eval env f $$ (eval env <$> a)
   QECon (n :$ sp) -> ECon $ n :$ (eval env <$> sp)
   QTString        -> TString
   QEString s      -> EString s
   QEOp n          -> EOp $ n :$ Nil
 
-evalComp :: HasCallStack => Stack (Maybe Value) -> QComp -> Comp
-evalComp env (QComp bs s t) = foldr (\ t b env -> TForAll (eval env <$> t) (\ v -> b (env :> Just v))) (\ env -> TRet (eval env <$> s) (eval env t)) bs env
+evalComp :: HasCallStack => Stack Value -> QComp -> Comp
+evalComp env (QComp bs s t) = foldr (\ t b env -> TForAll (eval env <$> t) (b . (env :>))) (\ env -> TRet (eval env <$> s) (eval env t)) bs env

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -66,7 +66,6 @@ import           Control.Lens (Lens', coerced, lens)
 import           Control.Monad (guard)
 import           Data.Foldable (asum, foldl', toList)
 import qualified Data.Map as Map
-import           Data.Maybe (fromMaybe)
 import           Data.Semialign
 import           Data.Text (Text)
 import           Data.Traversable (mapAccumL)
@@ -419,18 +418,18 @@ quoteComp d c = go d c QComp
     TForAll t b -> \ k -> go (succ d) (b (free d)) $ \ b s t' -> k ((quote d <$> t):b) s t'
     TRet s t    -> \ k -> k [] (quote d <$> s) (quote d t)
 
-eval :: HasCallStack => Stack (Maybe Value) -> Quote -> Value
+eval :: HasCallStack => Stack Value -> Quote -> Value
 eval env = \case
-  QVar v          -> unVar global (\ i -> fromMaybe (free (indexToLevel (Level (length env)) i)) (env ! getIndex i)) metavar v
+  QVar v          -> unVar global ((env !) . getIndex) metavar v
   QKType          -> KType
   QKInterface     -> KInterface
   QTSusp c        -> TSusp $ evalComp env c
-  QELam p cs      -> ELam p $ map (\ (p, b) -> Clause p (\ p -> eval (foldl' (\ env v -> env :> Just v) env p) b)) cs
+  QELam p cs      -> ELam p $ map (\ (p, b) -> Clause p (\ p -> eval (foldl' (:>) env p) b)) cs
   QApp f a        -> eval env f $$ (eval env <$> a)
   QECon (n :$ sp) -> ECon $ n :$ (eval env <$> sp)
   QTString        -> TString
   QEString s      -> EString s
   QEOp n          -> EOp $ n :$ Nil
 
-evalComp :: HasCallStack => Stack (Maybe Value) -> QComp -> Comp
-evalComp env (QComp bs s t) = foldr (\ t b env -> TForAll (eval env <$> t) (\ v -> b (env :> Just v))) (\ env -> TRet (eval env <$> s) (eval env t)) bs env
+evalComp :: HasCallStack => Stack Value -> QComp -> Comp
+evalComp env (QComp bs s t) = foldr (\ t b env -> TForAll (eval env <$> t) (b . (env :>))) (\ env -> TRet (eval env <$> s) (eval env t)) bs env

--- a/src/Facet/Core.hs
+++ b/src/Facet/Core.hs
@@ -14,6 +14,7 @@ module Facet.Core
 , instantiateClause
 , Binding(..)
 , icit_
+, type_
   -- ** Variables
 , Var(..)
 , unVar
@@ -145,6 +146,9 @@ data Binding a = Binding
 
 icit_ :: Lens' (Binding a) Icit
 icit_ = lens icit (\ b icit -> b{ icit })
+
+type_ :: Lens' (Binding a) a
+type_ = lens type' (\ b type' -> b{ type' })
 
 
 -- Variables

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -86,7 +86,7 @@ instantiate :: Quote ::: Comp -> Elab (Quote ::: Type)
 instantiate (e ::: _T) = case _T of
   TForAll (Binding Im _ _ _T) _B -> do
     m <- meta (Nothing ::: _T)
-    instantiate (QApp e (Im, QVar (Free (Index 0))) ::: _B (metavar m))
+    instantiate (QApp e (Im, QVar (Metavar m)) ::: _B (metavar m))
   _                              -> pure $ e ::: TSusp _T
 
 

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -22,9 +22,10 @@ module Facet.Elab
   -- * Errors
 , Err(..)
 , Reason(..)
-  -- * Machinery
+  -- * Unification
 , ElabContext(..)
 , sig_
+  -- * Machinery
 , Elab(..)
 , elab
 , check
@@ -526,7 +527,7 @@ expectRet :: String -> Type -> Elab (Sig Value, Type)
 expectRet = expectMatch (\case { TSusp (TRet s t) -> pure (s, t) ; _ -> Nothing }) "{_}"
 
 
--- Machinery
+-- Unification
 
 data ElabContext = ElabContext
   { graph   :: Graph
@@ -632,6 +633,8 @@ unify t1 t2 = case (t1, t2) of
     (Just e1, Just e2) -> f e1 e2
     _                  -> nope
 
+
+-- Machinery
 
 newtype Elab a = Elab { runElab :: forall sig m . Has (Fresh :+: Reader ElabContext :+: State Context :+: Throw Err :+: Trace) sig m => m a }
 

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -452,6 +452,14 @@ extendSig = maybe id (locally (sig_.interfaces_) . (++))
 depth :: Has (State (Context Type)) sig m => m Level
 depth = gets @(Context Type) level
 
+-- | Construct an environment suitable for evaluation from a 'Context'.
+toEnv :: Context Type -> Stack Type
+toEnv = go 0 . elems
+  where
+  go _ Nil              = Nil
+  go i (es :> Tm _   _) = go (succ i) es :> free (indexToLevel (Level (length es)) i)
+  go i (es :> Ty m d _) = go       i  es :> fromMaybe (metavar m) d
+
 runModule :: Has (State Module) sig m => ReaderC Module m a -> m a
 runModule m = do
   mod <- get

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -576,28 +576,28 @@ unify t1 t2 = case (t1, t2) of
     (True,  False, Just t)  -> unify (metavar v2) t >> restore
     (False, True,  Just t)  -> unify (metavar v1) t >> restore
     (False, False, _)       -> unify (metavar v1) (metavar v2) >> restore
-  (VNe (Metavar v1 :$ Nil), t2)                -> solve v1 t2
-  (t1, VNe (Metavar v2 :$ Nil))                -> solve v2 t1
-  (KType, KType)                               -> pure ()
-  (KType, _)                                   -> nope
-  (KInterface, KInterface)                     -> pure ()
-  (KInterface, _)                              -> nope
-  (TSusp c1, TSusp c2)                         -> comp c1 c2
-  (TSusp (TRet (Sig Nothing []) t1), t2)       -> unify t1 t2
-  (t1, TSusp (TRet (Sig Nothing []) t2))       -> unify t1 t2
-  (TSusp{}, _)                                 -> nope
-  (ELam{}, ELam{})                             -> nope
-  (ELam{}, _)                                  -> nope
-  (VNe (v1 :$ sp1), VNe (v2 :$ sp2))           -> var v1 v2 >> spine (pl unify) sp1 sp2
-  (VNe{}, _)                                   -> nope
-  (ECon (q1 :$ sp1), ECon (q2 :$ sp2))         -> unless (q1 == q2) nope >> spine unify sp1 sp2
-  (ECon{}, _)                                  -> nope
-  (TString, TString)                           -> pure ()
-  (TString, _)                                 -> nope
-  (EString e1, EString e2)                     -> unless (e1 == e2) nope
-  (EString{}, _)                               -> nope
-  (EOp (q1 :$ sp1), EOp (q2 :$ sp2))           -> unless (q1 == q2) nope >> spine (pl unify) sp1 sp2
-  (EOp{}, _)                                   -> nope
+  (VNe (Metavar v1 :$ Nil), t2)                      -> solve v1 t2
+  (t1, VNe (Metavar v2 :$ Nil))                      -> solve v2 t1
+  (KType, KType)                                     -> pure ()
+  (KType, _)                                         -> nope
+  (KInterface, KInterface)                           -> pure ()
+  (KInterface, _)                                    -> nope
+  (TSusp c1, TSusp c2)                               -> comp c1 c2
+  (TSusp (TRet (Sig Nothing []) t1), t2)             -> unify t1 t2
+  (t1, TSusp (TRet (Sig Nothing []) t2))             -> unify t1 t2
+  (TSusp{}, _)                                       -> nope
+  (ELam{}, ELam{})                                   -> nope
+  (ELam{}, _)                                        -> nope
+  (VNe (v1 :$ sp1), VNe (v2 :$ sp2))                 -> var v1 v2 >> spine (pl unify) sp1 sp2
+  (VNe{}, _)                                         -> nope
+  (ECon (q1 :$ sp1), ECon (q2 :$ sp2))               -> unless (q1 == q2) nope >> spine unify sp1 sp2
+  (ECon{}, _)                                        -> nope
+  (TString, TString)                                 -> pure ()
+  (TString, _)                                       -> nope
+  (EString e1, EString e2)                           -> unless (e1 == e2) nope
+  (EString{}, _)                                     -> nope
+  (EOp (q1 :$ sp1), EOp (q2 :$ sp2))                 -> unless (q1 == q2) nope >> spine (pl unify) sp1 sp2
+  (EOp{}, _)                                         -> nope
   where
   nope = couldNotUnify "mismatch" t1 t2
 

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -162,7 +162,7 @@ f $$ a = Synth $ trace "$$" $ do
 
 
 (|-) :: HasCallStack => Name ::: Type -> Elab a -> Elab a
-(n ::: _T) |- b = do
+(n ::: _T) |- b = trace "|-" $ do
   i <- depth
   modify (|> Tm n _T)
   a <- b

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -568,7 +568,7 @@ solve v = go v []
 
 -- FIXME: we don’t get good source references during unification
 unify :: HasCallStack => Type -> Type -> Elab ()
-unify t1 t2 = case (t1, t2) of
+unify t1 t2 = trace "unify" $ case (t1, t2) of
   (VNe (Metavar v1 :$ Nil), VNe (Metavar v2 :$ Nil)) -> onTop $ \ (g :=: d ::: _K) -> case (g == v1, g == v2, d) of
     (True,  True,  _)       -> restore
     (True,  False, Nothing) -> replace [g :=: Just (metavar v2) ::: _K]

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -59,7 +59,7 @@ import           Facet.Graph as Graph
 import           Facet.Lens
 import           Facet.Name hiding (L, R)
 import           Facet.Span (Pos, Span(..))
-import           Facet.Stack hiding ((!?))
+import           Facet.Stack
 import qualified Facet.Surface as S
 import           Facet.Syntax
 import           GHC.Stack

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -317,15 +317,15 @@ elabPattern sig = go
   -- FIXME: assert that the signature is empty
     TForAll (Binding Im _ _s _T) _B -> meta _T >>= inst . _B . metavar
     _T                              -> pure _T
-  subpatterns _A = \case
-    []   -> \ k -> k (TSusp _A) []
-    p:ps -> \ k -> do
+  subpatterns = flip $ foldr
+    (\ p rest _A k -> do
       -- FIXME: assert that the signature is empty
       (t@(Binding _ _ _s _A), _B) <- expectQuantifier "when checking constructor pattern" (TSusp _A)
       -- FIXME: is this right? should we use `free` instead? if so, what do we push onto the context?
       -- FIXME: I think this definitely isn’t right, as it instantiates variables which should remain polymorphic. We kind of need to open this existentially, I think?
       d <- depth
-      t |- goVal _A p (\ p' -> subpatterns (_B (free d)) ps (\ _T ps' -> k _T (p' : ps')))
+      t |- goVal _A p (\ p' -> rest (_B (free d)) (\ _T ps' -> k _T (p' : ps'))))
+      (\ _A k -> k (TSusp _A) [])
 
 
 string :: Text -> Synth Quote

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -614,7 +614,7 @@ unify t1 t2 = case (t1, t2) of
   spine f sp1 sp2 = unless (length sp1 == length sp2) nope >> sequenceA_ (zipWith f sp1 sp2)
 
   comp c1 c2 = case (c1, c2) of
-    (TForAll t1 b1, TForAll t2 b2) -> do { binding t1 t2 ; d <- depth ; comp (b1 (free d)) (b2 (free d)) ; pure () }
+    (TForAll t1 b1, TForAll t2 b2) -> do { binding t1 t2 ; d <- depth ; t1 |- comp (b1 (free d)) (b2 (free d)) ; pure () }
     (TForAll{}, _)                 -> nope
     (TRet s1 t1, TRet s2 t2)       -> sig s1 s2 >> unify t1 t2
     (TRet{}, _)                    -> nope

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -161,7 +161,7 @@ f $$ a = Synth $ trace "$$" $ do
   pure $ QApp f' (Ex, a') ::: TSusp (_B (free d))
 
 
-(|-) :: (HasCallStack, Has (State Context) sig m) => Name ::: Type -> m a -> m a
+(|-) :: HasCallStack => Name ::: Type -> Elab a -> Elab a
 (n ::: _T) |- b = do
   i <- depth
   modify (|> Tm n _T)

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -317,11 +317,11 @@ elabPattern sig = go
   -- FIXME: assert that the signature is empty
     TForAll (Binding Im _ _s _T) _B -> meta _T >>= inst . _B . metavar
     _T                              -> pure _T
-  subpatterns _T' = \case
-    []   -> \ k -> k (TSusp _T') []
+  subpatterns _A = \case
+    []   -> \ k -> k (TSusp _A) []
     p:ps -> \ k -> do
       -- FIXME: assert that the signature is empty
-      (t@(Binding _ _ _s _A), _B) <- expectQuantifier "when checking constructor pattern" (TSusp _T')
+      (t@(Binding _ _ _s _A), _B) <- expectQuantifier "when checking constructor pattern" (TSusp _A)
       -- FIXME: is this right? should we use `free` instead? if so, what do we push onto the context?
       -- FIXME: I think this definitely isn’t right, as it instantiates variables which should remain polymorphic. We kind of need to open this existentially, I think?
       d <- depth

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -452,14 +452,6 @@ extendSig = maybe id (locally (sig_.interfaces_) . (++))
 depth :: Has (State (Context Type)) sig m => m Level
 depth = gets @(Context Type) level
 
--- | Construct an environment suitable for evaluation from a 'Context'.
-toEnv :: Context Type -> Stack Type
-toEnv = go 0 . elems
-  where
-  go _ Nil              = Nil
-  go i (es :> Tm _   _) = go (succ i) es :> free (indexToLevel (Level (length es)) i)
-  go i (es :> Ty m d _) = go       i  es :> fromMaybe (metavar m) d
-
 runModule :: Has (State Module) sig m => ReaderC Module m a -> m a
 runModule m = do
   mod <- get

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -95,7 +95,7 @@ switch (Synth m) = Check $ trace "switch" . \ _K -> m >>= \ (a ::: _K') -> a <$ 
 
 as :: Check Quote ::: Check Quote -> Synth Quote
 as (m ::: _T) = Synth $ trace "as" $ do
-  env <- gets (maybe Nil pure . entryDef <=< elems)
+  env <- gets (fmap entryDef . elems)
   _T' <- eval env <$> check (_T ::: KType)
   a <- check (m ::: _T')
   pure $ a ::: _T'
@@ -234,7 +234,7 @@ elabComp :: S.Ann S.Comp -> Synth QComp
 elabComp (S.Ann s _ (S.Comp bs d t)) = Synth $ setSpan s . trace "elabComp" $
   foldr (\ b k bs -> do
     b' <- check (snd b ::: KType)
-    env <- gets (maybe Nil pure . entryDef <=< elems)
+    env <- gets (fmap entryDef . elems)
     fmap (eval env) b' >- k (bs . (b':)))
   (\ bs' -> do
     d' <- traverse (traverse (check . (::: KInterface) . elabSig)) d
@@ -349,7 +349,7 @@ elabDataDef (dname ::: _T) constructors = trace "elabDataDef" $ do
     -- FIXME: we should unpack the Comp instead of quoting so we don’t have to re-eval everything.
     let QComp bs _ _ = quoteComp 0 _T
         bs' = map (set icit_ Im) bs
-    QComp bs'' s t <- elab $ foldr (\ b k -> gets (maybe Nil pure . entryDef <=< elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs'
+    QComp bs'' s t <- elab $ foldr (\ b k -> gets (fmap entryDef . elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs'
     let c_T = evalComp Nil (QComp (bs' <> bs'') s t)
     pure $ n :=: Just (DTerm (con (mname :.: n) Nil c_T)) ::: c_T
   -- FIXME: constructor functions should have signatures, but constructors should not.
@@ -371,7 +371,7 @@ elabInterfaceDef _T constructors = trace "elabInterfaceDef" $ do
     -- FIXME: we should unpack the Comp instead of quoting so we don’t have to re-eval everything.
     let QComp bs _ _ = quoteComp 0 _T
         bs' = map (set icit_ Im) bs
-    QComp bs'' s t <- elab $ foldr (\ b k -> gets (maybe Nil pure . entryDef <=< elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs'
+    QComp bs'' s t <- elab $ foldr (\ b k -> gets (fmap entryDef . elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs'
     -- FIXME: check that the interface is a member of the sig.
     let _T = evalComp Nil (QComp (bs' <> bs'') s t)
     pure $ n :=: Nothing ::: _T

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -228,8 +228,8 @@ elabSig (S.Ann s _ (S.Interface (S.Ann s' _ n) sp)) = Check $ \ _T -> setSpan s 
   check (switch (foldl' ($$) (mapSynth (setSpan s') (var n)) (checkExpr <$> sp)) ::: _T)
 
 elabComp :: S.Ann S.Comp -> Synth QComp
-elabComp (S.Ann s _ (S.Comp bs d t)) = Synth $ setSpan s . trace "elabComp" $
-  foldr (\ b k bs -> do
+elabComp (S.Ann s _ (S.Comp bs d t)) = Synth $ setSpan s . trace "elabComp" $ foldr
+  (\ b k bs -> do
     b' <- check (snd b ::: KType)
     env <- gets toEnv
     fmap (uncurry eval env) b' |- k (bs . (b':)))

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -346,6 +346,7 @@ elabDataDef
 elabDataDef (dname ::: _T) constructors = trace "elabDataDef" $ do
   mname <- ask
   cs <- for constructors $ runWithSpan $ \ (n ::: t) -> do
+    -- FIXME: we should unpack the Comp instead of quoting so we don’t have to re-eval everything.
     let QComp bs _ _ = quoteComp 0 _T
     QComp bs' s t <- elab $ foldr (\ b k -> gets (fmap entryDef . elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs
     let c_T = evalComp Nil (QComp (bs <> bs') s t)

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -161,10 +161,11 @@ f $$ a = Synth $ trace "$$" $ do
   pure $ QApp f' (Ex, a') ::: TSusp (_B (free d))
 
 
-(|-) :: HasCallStack => Name ::: Type -> Elab a -> Elab a
-(n ::: _T) |- b = trace "|-" $ do
+(|-) :: HasCallStack => Binding Value -> Elab a -> Elab a
+-- FIXME: should this do something about the signature?
+Binding _ n _s _T |- b = trace "|-" $ do
   i <- depth
-  modify (|> Tm n _T)
+  modify (|> Tm (fromMaybe __ n) _T)
   a <- b
   let extract (gamma :> Tm _ _) | i == level (Context gamma) = gamma
       extract (gamma :> e@Ty{})                              = extract gamma :> e
@@ -176,8 +177,7 @@ infix 1 |-
 
 
 (>-) :: HasCallStack => Binding Value -> Elab a -> Elab a
--- FIXME: should this do something about the signature?
-Binding _ n _s _T >- m = trace ">-" $ fromMaybe __ n ::: _T |- m
+b >- m = trace ">-" $ b |- m
 
 infix 1 >-
 

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -156,8 +156,9 @@ f $$ a = Synth $ trace "$$" $ do
   f' ::: _F <- synth f
   (Binding _ _ s _A, _B) <- expectQuantifier "in application" _F
   a' <- extendSig s (check (a ::: _A))
-  d <- depth
-  pure $ QApp f' (Ex, a') ::: TSusp (_B (free d))
+  env <- gets toEnv
+  let a'' = uncurry eval env a'
+  pure $ QApp f' (Ex, a') ::: TSusp (_B a'')
 
 
 (|-) :: HasCallStack => Binding Value -> Elab a -> Elab a

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -447,7 +447,7 @@ extendSig :: Has (Reader ElabContext) sig m => Maybe [Value] -> m a -> m a
 extendSig = maybe id (locally (sig_.interfaces_) . (++))
 
 depth :: Has (State Context) sig m => m Level
-depth = gets @Context level
+depth = gets level
 
 runModule :: Has (State Module) sig m => ReaderC Module m a -> m a
 runModule m = do

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -119,7 +119,7 @@ resolveQ = resolveWith lookupD
 global :: Q Name ::: Comp -> Synth Quote
 global (q ::: _T) = Synth $ instantiate (QVar (Global q) ::: _T)
 
-lookupInContext :: Q Name -> Context -> Maybe (Index, Type)
+lookupInContext :: Q Name -> Context Type -> Maybe (Index, Type)
 lookupInContext (m:.:n)
   | m == Nil  = lookupIndex n
   | otherwise = const Nothing
@@ -160,7 +160,7 @@ f $$ a = Synth $ trace "$$" $ do
   pure $ QApp f' (Ex, a') ::: TSusp (_B (free d))
 
 
-(|-) :: (HasCallStack, Has (State Context) sig m) => Name ::: Type -> m a -> m a
+(|-) :: (HasCallStack, Has (State (Context Type)) sig m) => Name ::: Type -> m a -> m a
 (n ::: _T) |- b = do
   i <- depth
   modify (|> Tm n _T)
@@ -169,7 +169,7 @@ f $$ a = Synth $ trace "$$" $ do
       extract (gamma :> e@Ty{})                              = extract gamma :> e
       extract (_     :> _)                                   = error "bad context entry"
       extract Nil                                            = error "bad context"
-  a <$ modify (Context . extract . elems)
+  a <$ modify (Context . extract . elems @Type)
 
 infix 1 |-
 
@@ -449,8 +449,8 @@ insertEffectVar _E = go
 extendSig :: Has (Reader ElabContext) sig m => Maybe [Value] -> m a -> m a
 extendSig = maybe id (locally (sig_.interfaces_) . (++))
 
-depth :: Has (State Context) sig m => m Level
-depth = gets @Context level
+depth :: Has (State (Context Type)) sig m => m Level
+depth = gets @(Context Type) level
 
 runModule :: Has (State Module) sig m => ReaderC Module m a -> m a
 runModule m = do
@@ -470,7 +470,7 @@ runWithSpan k (S.Ann s _ a) = runReader s (k a)
 data Err = Err
   { span      :: Span
   , reason    :: Reason
-  , context   :: Context
+  , context   :: Context Type
   , callStack :: Stack Message -- FIXME: keep source references for each message.
   }
 
@@ -543,7 +543,7 @@ span_ :: Lens' ElabContext Span
 span_ = lens (span :: ElabContext -> Span) (\ e span -> (e :: ElabContext){ span })
 
 
-onTop :: HasCallStack => (Meta :=: Maybe Value ::: Type -> Elab (Maybe Suffix)) -> Elab ()
+onTop :: HasCallStack => (Meta :=: Maybe Value ::: Type -> Elab (Maybe (Suffix Type))) -> Elab ()
 onTop f = do
   ctx <- get
   (gamma, elem) <- case elems ctx of
@@ -633,7 +633,7 @@ unify t1 t2 = case (t1, t2) of
     _                  -> nope
 
 
-newtype Elab a = Elab { runElab :: forall sig m . Has (Fresh :+: Reader ElabContext :+: State Context :+: Throw Err :+: Trace) sig m => m a }
+newtype Elab a = Elab { runElab :: forall sig m . Has (Fresh :+: Reader ElabContext :+: State (Context Type) :+: Throw Err :+: Trace) sig m => m a }
 
 instance Functor Elab where
   fmap f (Elab m) = Elab (fmap f m)
@@ -645,7 +645,7 @@ instance Applicative Elab where
 instance Monad Elab where
   Elab m >>= f = Elab $ m >>= runElab . f
 
-instance Algebra (Fresh :+: Reader ElabContext :+: State Context :+: Throw Err :+: Trace) Elab where
+instance Algebra (Fresh :+: Reader ElabContext :+: State (Context Type) :+: Throw Err :+: Trace) Elab where
   alg hdl sig ctx = case sig of
     L fresh             -> Elab $ alg (runElab . hdl) (inj fresh) ctx
     R (L rctx)          -> Elab $ alg (runElab . hdl) (inj rctx)  ctx
@@ -654,7 +654,7 @@ instance Algebra (Fresh :+: Reader ElabContext :+: State Context :+: Throw Err :
     R (R (R (R trace))) -> Elab $ alg (runElab . hdl) (inj trace) ctx
 
 elab :: Has (Reader Graph :+: Reader MName :+: Reader Module :+: Reader Span :+: Throw Err :+: Time Instant :+: Trace) sig m => Elab a -> m a
-elab = evalFresh 0 . evalState Context.empty . (\ m -> do { ctx <- mkContext ; runReader ctx m}) . runElab
+elab = evalFresh 0 . evalState (Context.empty @Type) . (\ m -> do { ctx <- mkContext ; runReader ctx m}) . runElab
   where
   mkContext = ElabContext <$> ask <*> ask <*> ask <*> pure (Sig Nothing []) <*> ask
 

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -615,6 +615,7 @@ unify t1 t2 = case (t1, t2) of
   spine f sp1 sp2 = unless (length sp1 == length sp2) nope *> sequenceA (zipWith f sp1 sp2)
 
   comp c1 c2 = case (c1, c2) of
+    -- FIXME: unify purely statefully so we don’t have to substitute
     (TForAll t1 b1, TForAll t2 b2) -> TForAll <$> binding t1 t2 <*> do { d <- depth ; b' <- comp (b1 (free d)) (b2 (free d)) ; pure (\ v -> bindComp d v b') }
     (TForAll{}, _)                 -> nope
     (TRet s1 t1, TRet s2 t2)       -> TRet <$> sig s1 s2 <*> unify t1 t2

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -618,7 +618,7 @@ unify t1 t2 = trace "unify" $ value t1 t2
     _                  -> nope
 
   solve :: HasCallStack => Meta -> Type -> Elab ()
-  solve v = go v []
+  solve v = trace "solve" . go v []
     where
     go v ext t = onTop $ \ (m :=: d ::: _K) -> case (m == v, occursIn (== Metavar m) t || occursInSuffix (== Metavar m) ext, d) of
       (True,  True,  _)       -> mismatch "infinite type" (Right (metavar m)) t

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -95,7 +95,7 @@ switch (Synth m) = Check $ trace "switch" . \ _K -> m >>= \ (a ::: _K') -> a <$ 
 
 as :: Check Quote ::: Check Quote -> Synth Quote
 as (m ::: _T) = Synth $ trace "as" $ do
-  env <- gets (fmap entryDef . elems)
+  env <- gets (maybe Nil pure . entryDef <=< elems)
   _T' <- eval env <$> check (_T ::: KType)
   a <- check (m ::: _T')
   pure $ a ::: _T'
@@ -234,7 +234,7 @@ elabComp :: S.Ann S.Comp -> Synth QComp
 elabComp (S.Ann s _ (S.Comp bs d t)) = Synth $ setSpan s . trace "elabComp" $
   foldr (\ b k bs -> do
     b' <- check (snd b ::: KType)
-    env <- gets (fmap entryDef . elems)
+    env <- gets (maybe Nil pure . entryDef <=< elems)
     fmap (eval env) b' >- k (bs . (b':)))
   (\ bs' -> do
     d' <- traverse (traverse (check . (::: KInterface) . elabSig)) d
@@ -349,7 +349,7 @@ elabDataDef (dname ::: _T) constructors = trace "elabDataDef" $ do
     -- FIXME: we should unpack the Comp instead of quoting so we don’t have to re-eval everything.
     let QComp bs _ _ = quoteComp 0 _T
         bs' = map (set icit_ Im) bs
-    QComp bs'' s t <- elab $ foldr (\ b k -> gets (fmap entryDef . elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs'
+    QComp bs'' s t <- elab $ foldr (\ b k -> gets (maybe Nil pure . entryDef <=< elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs'
     let c_T = evalComp Nil (QComp (bs' <> bs'') s t)
     pure $ n :=: Just (DTerm (con (mname :.: n) Nil c_T)) ::: c_T
   -- FIXME: constructor functions should have signatures, but constructors should not.
@@ -371,7 +371,7 @@ elabInterfaceDef _T constructors = trace "elabInterfaceDef" $ do
     -- FIXME: we should unpack the Comp instead of quoting so we don’t have to re-eval everything.
     let QComp bs _ _ = quoteComp 0 _T
         bs' = map (set icit_ Im) bs
-    QComp bs'' s t <- elab $ foldr (\ b k -> gets (fmap entryDef . elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs'
+    QComp bs'' s t <- elab $ foldr (\ b k -> gets (maybe Nil pure . entryDef <=< elems) >>= \ env -> fmap (eval env) b >- k) (check (switch (elabComp t) ::: KType)) bs'
     -- FIXME: check that the interface is a member of the sig.
     let _T = evalComp Nil (QComp (bs' <> bs'') s t)
     pure $ n :=: Nothing ::: _T

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -276,8 +276,8 @@ force e = Synth $ trace "force" $ do
 
 -- FIXME: go find the pattern matching matrix algorithm
 elabClauses :: [S.Clause] -> Check Quote
-elabClauses [S.Clause (S.Ann _ _ (S.PVal (S.Ann _ _ (S.PVar n)))) b] = lam n $ checkExpr b
-elabClauses cs = Check $ \ _T -> do
+elabClauses [S.Clause (S.Ann _ _ (S.PVal (S.Ann _ _ (S.PVar n)))) b] = mapCheck (trace "elabClauses") $ lam n $ checkExpr b
+elabClauses cs = Check $ \ _T -> trace "elabClauses" $ do
   -- FIXME: use the signature to elaborate the pattern
   (Binding _ _ s _A, _B) <- expectQuantifier "when checking clauses" _T
   d <- depth

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -618,7 +618,6 @@ unify t1 t2 = case (t1, t2) of
   spine f sp1 sp2 = unless (length sp1 == length sp2) nope >> sequenceA_ (zipWith f sp1 sp2)
 
   comp c1 c2 = case (c1, c2) of
-    -- FIXME: unify purely statefully so we don’t have to substitute
     (TForAll t1 b1, TForAll t2 b2) -> do { binding t1 t2 ; d <- depth ; comp (b1 (free d)) (b2 (free d)) ; pure () }
     (TForAll{}, _)                 -> nope
     (TRet s1 t1, TRet s2 t2)       -> sig s1 s2 >> unify t1 t2

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -162,6 +162,7 @@ f $$ a = Synth $ trace "$$" $ do
 
 
 (|-) :: HasCallStack => Binding Value -> Elab a -> Elab a
+-- FIXME: this isn’t _quite_ the shape we want to push onto the context because e.g. constructor patterns can bind multiple variables but they’d all have the same icit & signature.
 -- FIXME: should this do something about the signature?
 Binding _ n _s _T |- b = trace "|-" $ do
   i <- depth

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -166,6 +166,7 @@ f $$ a = Synth $ trace "$$" $ do
 -- FIXME: should this do something about the signature?
 Binding _ n _s _T |- b = trace "|-" $ do
   i <- depth
+  -- FIXME: should the context allow names in Maybe?
   modify (|> Tm (fromMaybe __ n) _T)
   a <- b
   let extract (gamma :> Tm _ _) | i == level (Context gamma) = gamma

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -560,7 +560,7 @@ unify t1 t2 = trace "unify" $ value t1 t2
   nope = couldNotUnify "mismatch" t1 t2
 
   value t1 t2 = case (t1, t2) of
-    (VNe (Metavar v1 :$ Nil), VNe (Metavar v2 :$ Nil)) -> onTop $ \ (g :=: d ::: _K) -> case (g == v1, g == v2, d) of
+    (VNe (Metavar v1 :$ Nil), VNe (Metavar v2 :$ Nil)) -> trace "flex-flex" $ onTop $ \ (g :=: d ::: _K) -> case (g == v1, g == v2, d) of
       (True,  True,  _)       -> restore
       (True,  False, Nothing) -> replace [g :=: Just (metavar v2) ::: _K]
       (False, True,  Nothing) -> replace [g :=: Just (metavar v1) ::: _K]

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -316,16 +316,16 @@ elabPattern sig = go
   inst = \case
   -- FIXME: assert that the signature is empty
     TForAll (Binding Im _ _s _T) _B -> meta _T >>= inst . _B . metavar
-    _T                              -> pure (TSusp _T)
+    _T                              -> pure _T
   subpatterns _T' = \case
-    []   -> \ k -> k _T' []
+    []   -> \ k -> k (TSusp _T') []
     p:ps -> \ k -> do
       -- FIXME: assert that the signature is empty
-      (t@(Binding _ _ _s _A), _B) <- expectQuantifier "when checking constructor pattern" _T'
+      (t@(Binding _ _ _s _A), _B) <- expectQuantifier "when checking constructor pattern" (TSusp _T')
       -- FIXME: is this right? should we use `free` instead? if so, what do we push onto the context?
       -- FIXME: I think this definitely isn’t right, as it instantiates variables which should remain polymorphic. We kind of need to open this existentially, I think?
       d <- depth
-      t |- goVal _A p (\ p' -> subpatterns (TSusp (_B (free d))) ps (\ _T ps' -> k _T (p' : ps')))
+      t |- goVal _A p (\ p' -> subpatterns (_B (free d)) ps (\ _T ps' -> k _T (p' : ps')))
 
 
 string :: Text -> Synth Quote

--- a/src/Facet/Eval.hs
+++ b/src/Facet/Eval.hs
@@ -35,10 +35,10 @@ eval = \case
 
 -- Machinery
 
-runEval :: (Q Name :$ (Pl, Value) -> (Value -> m r) -> m r) -> (a -> m r) -> Eval m a -> m r
+runEval :: (Q Name :$ (Icit, Value) -> (Value -> m r) -> m r) -> (a -> m r) -> Eval m a -> m r
 runEval hdl k (Eval m) = m hdl k
 
-newtype Eval m a = Eval (forall r . (Q Name :$ (Pl, Value) -> (Value -> m r) -> m r) -> (a -> m r) -> m r)
+newtype Eval m a = Eval (forall r . (Q Name :$ (Icit, Value) -> (Value -> m r) -> m r) -> (a -> m r) -> m r)
 
 instance Functor (Eval m) where
   fmap f (Eval m) = Eval $ \ hdl k -> m hdl (k . f)

--- a/src/Facet/Name.hs
+++ b/src/Facet/Name.hs
@@ -3,6 +3,7 @@ module Facet.Name
 , Level(..)
 , levelToIndex
 , indexToLevel
+, Meta(..)
 , FVs(..)
 , getFVs
 , Vars(..)
@@ -47,6 +48,10 @@ levelToIndex (Level d) (Level level) = Index $ d - level - 1
 
 indexToLevel :: Level -> Index -> Level
 indexToLevel (Level d) (Index index) = Level $ d - index - 1
+
+
+newtype Meta = Meta { getMeta :: Int }
+  deriving (Eq, Ord, Show)
 
 
 newtype FVs = FVs { runFVs :: IntSet.IntSet -> IntSet.IntSet -> IntSet.IntSet }

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -39,8 +39,10 @@ rethrowElabErrors src = L.runThrow rethrow
         , sort  :> s
         , print :> n'
         , ctx   :> reAnnotate Code (getPrint (ann (n' ::: printValue print _T))) <> case e of
-          Ty _ (Just v) _ -> space <> pretty '=' <+> reAnnotate Code (getPrint (printValue print v))
-          _               -> mempty )
+          Ty _ v _ -> space <> pretty '=' <+> case v of
+            Just v -> reAnnotate Code (getPrint (printValue print v))
+            _      -> pretty '?'
+          _        -> mempty )
   name = \case
     STerm -> intro
     _     -> tintro

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -34,13 +34,13 @@ rethrowElabErrors src = L.runThrow rethrow
     let _T = entryType e
         s = sortOf sort _T
         n' = case e of
-          Tm n   _ -> name s n d
-          Ty m _ _ -> meta m
+          Rigid n   _ -> name s n d
+          Flex  m _ _ -> meta m
     in  ( succ d
         , sort  :> s
         , print :> n'
         , ctx   :> reAnnotate Code (getPrint (ann (n' ::: printValue print _T))) <> case e of
-          Ty _ v _ -> space <> pretty '=' <+> case v of
+          Flex _ v _ -> space <> pretty '=' <+> case v of
             Just v -> reAnnotate Code (getPrint (printValue print v))
             _      -> pretty '?'
           _        -> mempty )

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -8,6 +8,7 @@ import qualified Facet.Carrier.Throw.Inject as L
 import           Facet.Context
 import           Facet.Core (Sort(..), Type, sortOf)
 import           Facet.Elab as Elab
+import           Facet.Name (__)
 import           Facet.Notice as Notice
 import           Facet.Pretty
 import           Facet.Print as Print
@@ -33,7 +34,7 @@ rethrowElabErrors src = L.runThrow rethrow
   combine (d, sort, print, ctx) e =
     let _T = entryType e
         s = sortOf sort _T
-        n' = name s (entryName e) d
+        n' = name s (case e of { Tm n _ -> n ; Ty{} -> __ }) d
     in  ( succ d
         , sort  :> s
         , print :> n'

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -8,7 +8,6 @@ import qualified Facet.Carrier.Throw.Inject as L
 import           Facet.Context
 import           Facet.Core (Sort(..), Type, sortOf)
 import           Facet.Elab as Elab
-import           Facet.Name (__)
 import           Facet.Notice as Notice
 import           Facet.Pretty
 import           Facet.Print as Print
@@ -34,7 +33,9 @@ rethrowElabErrors src = L.runThrow rethrow
   combine (d, sort, print, ctx) e =
     let _T = entryType e
         s = sortOf sort _T
-        n' = name s (case e of { Tm n _ -> n ; Ty{} -> __ }) d
+        n' = case e of
+          Tm n   _ -> name s n d
+          Ty m _ _ -> meta m
     in  ( succ d
         , sort  :> s
         , print :> n'

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -235,7 +235,7 @@ printModule (C.Module mname is _ ds) = module_
   defn (a :=: b) = group a <> hardline <> group b
 
 intro, tintro :: Name -> Level -> Print
-intro = name lower
+intro  = name lower
 tintro = name upper
 qvar (_ :.: n) = setPrec Var (pretty n)
 

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -173,8 +173,6 @@ printValue env = \case
   C.KInterface -> annotate Type $ pretty "Interface"
   C.TSusp t -> printComp env t
   C.ELam p b -> comp . nest 2 . group . commaSep $ map (clause env p) b
-  -- FIXME: there’s no way of knowing if the quoted variable was a type or expression variable
-  -- FIXME: should maybe print the quoted variable differently so it stands out.
   C.VNe (h :$ e) ->
     let elim h sp  Nil     = case sp Nil of
           Nil -> h

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -144,7 +144,7 @@ f $$ a = askingPrec $ \case
 ($$*) :: Foldable t => Print -> t Print -> Print
 ($$*) = fmap group . foldl' ($$)
 
-(>~>) :: ((Pl, Print) ::: Print) -> Print -> Print
+(>~>) :: ((Icit, Print) ::: Print) -> Print -> Print
 ((pl, n) ::: t) >~> b = prec FnR (flatAlt (column (\ i -> nesting (\ j -> stimes (j + 3 - i) space))) mempty <> group (align (unPl braces parens pl (space <> ann (setPrec Var n ::: t) <> line))) </> arrow <+> b)
 
 

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -182,7 +182,7 @@ printValue env = \case
         elim h sp  (es:>a) = elim h (sp . (:> fmap (printValue env) a)) es
         -- FIXME: this throws an exception when pretty-printing the metacontext because entries can depend on variables bound in the context
         -- FIXME: should push metas into the context and look up stuff by meta name
-        h' = C.unVar (group . qvar) ((env !) . getIndex . levelToIndex d) (pretty . getMeta) h
+        h' = C.unVar (group . qvar) ((env !) . getIndex . levelToIndex d) meta h
     in elim h' id e
   C.ECon (n :$ p) -> app (group (qvar n)) (fmap ((Ex,) . printValue env) p)
   C.EOp (q :$ sp) -> app (group (qvar q)) (fmap (fmap (printValue env)) sp)

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -180,7 +180,8 @@ printValue env = \case
           sp  -> app h sp
         elim h sp  (es:>a) = elim h (sp . (:> fmap (printValue env) a)) es
         -- FIXME: this throws an exception when pretty-printing the metacontext because entries can depend on variables bound in the context
-        h' = C.unVar (group . qvar) ((env !) . getIndex . levelToIndex d) h
+        -- FIXME: should push metas into the context and look up stuff by meta name
+        h' = C.unVar (group . qvar) ((env !) . getIndex . levelToIndex d) (pretty . getMeta) h
     in elim h' id e
   C.ECon (n :$ p) -> app (group (qvar n)) (fmap ((Ex,) . printValue env) p)
   C.EOp (q :$ sp) -> app (group (qvar q)) (fmap (fmap (printValue env)) sp)

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -41,7 +41,7 @@ import           Facet.Notice.Elab
 import           Facet.Notice.Parser
 import           Facet.Parser as Parser
 import           Facet.Pretty
-import           Facet.Print as Print hiding (Comp, Type)
+import           Facet.Print as Print hiding (Comp, Type, meta)
 import           Facet.REPL.Parser
 import           Facet.Source (Source(..), sourceFromString)
 import           Facet.Span (Span)

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -192,12 +192,12 @@ showType, showEval :: S.Ann S.Expr -> Action
 
 showType e = Action $ do
   e ::: _T <- elab $ Elab.elab (Elab.synth (Elab.synthExpr e))
-  let e'  = Core.eval Nil e
+  let e'  = Core.eval Nil mempty e
   outputDocLn (prettyCode (ann (printValue Nil e' ::: printValue Nil _T)))
 
 showEval e = Action $ do
   (dElab, e' ::: _T) <- time $ elab $ Elab.elab $ locally (Elab.sig_.interfaces_) (VNe (Global (fromList ["Effect", "Console"]:.:U "Output"):$Nil):) $ Elab.synth (Elab.synthExpr e)
-  let e''  = Core.eval Nil e'
+  let e''  = Core.eval Nil mempty e'
   (dEval, e'') <- time $ elab $ runEvalMain (eval e'')
   outputStrLn $ show dElab
   outputStrLn $ show dEval

--- a/src/Facet/Stack.hs
+++ b/src/Facet/Stack.hs
@@ -3,7 +3,6 @@ module Facet.Stack
 ( Stack(..)
 , fromList
 , (!)
-, (!?)
 ) where
 
 import Data.Foldable (foldl', toList)
@@ -85,12 +84,3 @@ as' ! i' = withFrozenCallStack $ go as' i'
     | i == 0     = a
     | otherwise  = go as (i - 1)
   go _         _ = error $ "Facet.Stack.!: index (" <> show i' <> ") out of bounds (" <> show (length as') <> ")"
-
--- | Safe indexing (returns 'Nothing' for out-of-bounds indices).
---
--- The index functions like a De Bruijn index, counting down from the /top/ of the stack (i.e. right-to-left).
-(!?) :: Stack a -> Int -> Maybe a
-(as :> a) !? i
-  | i == 0     = Just a
-  | otherwise  = as !? (i - 1)
-_         !? _ = Nothing

--- a/src/Facet/Style.hs
+++ b/src/Facet/Style.hs
@@ -11,7 +11,6 @@ module Facet.Style
 import           Data.Colour.RGBSpace.HSL
 import           Data.List.NonEmpty (NonEmpty(..))
 import           Data.Maybe (fromMaybe)
-import           Facet.Name (Level(getLevel))
 import qualified Facet.Notice as Notice
 import           Facet.Pretty
 import           Facet.Print as Print
@@ -66,7 +65,7 @@ terminalStyle = \case
 terminalCodeStyle :: Print.Highlight -> [SGR]
 terminalCodeStyle = \case
   Nest i  -> [setRGB (pick i 0.4 0.8)]
-  Name i  -> [setRGB (pick (-getLevel i) 0.8 0.6)]
+  Name i  -> [setRGB (pick (-i) 0.8 0.6)]
   Keyword -> [setRGB (hsl 300 0.7 0.4)]
   Op      -> [setRGB (hsl 180 0.7 0.4)]
   Type    -> [setRGB (hsl 60 0.5 0.5)]

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -64,7 +64,7 @@ data Comp = Comp
 
 
 data Binding = Binding
-  { pl    :: Icit
+  { icit  :: Icit
   -- | The names bound by this value. 'Nothing' indicates an unnamed binding (i.e. a regular old function type argument like @A -> B@), whereas 'Just' indicates one or more names are bound to a single type (e.g. a quantifier like @{ A, B : Type } -> C@).
   --
   -- This technically represents the same number of (total) cases as @[]@ would, but forces disjoint handling so we don’t accidentally e.g. bind or apply over a non-binding argument and truncate the list.

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -64,7 +64,7 @@ data Comp = Comp
 
 
 data Binding = Binding
-  { pl    :: Pl
+  { pl    :: Icit
   -- | The names bound by this value. 'Nothing' indicates an unnamed binding (i.e. a regular old function type argument like @A -> B@), whereas 'Just' indicates one or more names are bound to a single type (e.g. a quantifier like @{ A, B : Type } -> C@).
   --
   -- This technically represents the same number of (total) cases as @[]@ would, but forces disjoint handling so we don’t accidentally e.g. bind or apply over a non-binding argument and truncate the list.

--- a/src/Facet/Syntax.hs
+++ b/src/Facet/Syntax.hs
@@ -7,7 +7,7 @@ module Facet.Syntax
 , (:$)(..)
 , splitl
 , splitr
-, Pl(..)
+, Icit(..)
 , unPl
 ) where
 
@@ -112,26 +112,26 @@ splitr un = go id
 
 
 -- | Im/explicit.
-data Pl
+data Icit
   = Im
   | Ex
   deriving (Bounded, Enum, Eq, Ord, Show)
 
-instance Semigroup Pl where
+instance Semigroup Icit where
   Im <> Im = Im
   _  <> _  = Ex
 
-instance Monoid Pl where
+instance Monoid Icit where
   mempty = Im
 
-instance Semiring Pl where
+instance Semiring Icit where
   Ex >< Ex = Ex
   _  >< _  = Im
 
-instance Unital Pl where
+instance Unital Icit where
   one = Ex
 
-unPl :: a -> a -> Pl -> a
+unPl :: a -> a -> Icit -> a
 unPl im ex = \case
   Im -> im
   Ex -> ex

--- a/test/Facet/Core/Test.hs
+++ b/test/Facet/Core/Test.hs
@@ -1,9 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Facet.Core.Test
 ( tests
 ) where
 
-import Hedgehog
+import Facet.Core
+import Facet.Name
+import Facet.Stack
+import Facet.Syntax
+import Hedgehog hiding (eval)
 
 tests :: IO Bool
 tests = checkParallel $$(discover)
+
+prop_quotation_inverse = property $ do
+  let init = QTSusp (QComp [Binding Im (Just (U "ε")) Nothing QKInterface, Binding Im (Just (U "A")) Nothing QKType, Binding Ex (Just (U "x")) Nothing (QVar (Free 0)) ] (Sig (Just (QVar (Free 2))) []) (QVar (Free 1)))
+  quote 0 (eval Nil mempty init) === init

--- a/test/Facet/Core/Test.hs
+++ b/test/Facet/Core/Test.hs
@@ -1,0 +1,2 @@
+module Facet.Core.Test
+() where

--- a/test/Facet/Core/Test.hs
+++ b/test/Facet/Core/Test.hs
@@ -1,2 +1,9 @@
+{-# LANGUAGE TemplateHaskell #-}
 module Facet.Core.Test
-() where
+( tests
+) where
+
+import Hedgehog
+
+tests :: IO Bool
+tests = checkParallel $$(discover)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -3,11 +3,13 @@ module Main
 ) where
 
 import qualified Facet.Carrier.Parser.Church.Test
+import qualified Facet.Core.Test
 import qualified Facet.Source.Test
 import           Hedgehog.Main
 
 main :: IO ()
 main = defaultMain
   [ Facet.Carrier.Parser.Church.Test.tests
+  , Facet.Core.Test.tests
   , Facet.Source.Test.tests
   ]


### PR DESCRIPTION
This PR migrates unification from operating on a substitution to operating on a mixed prefix context, à la [_Type Inference in Context_](http://www.cs.ru.nl/~james/RESEARCH/msfp2010-paper.pdf), Adam Gundry, Conor McBride, James McKinna.

It also migrates to the construction of syntax to a quoted, first-order AST, with evaluation to a HOAS form.