### PR TITLE
Computations

### DIFF
--- a/lib/Effect/State.facet
+++ b/lib/Effect/State.facet
@@ -10,7 +10,7 @@ interface State : (S : Type) -> Interface
 , put : S -> [State S] Unit }
 
 modify : { S : Type } -> (f : S -> S) -> [State S] Unit
-{ put (f get!) }
+{ (put (f get!))! }
 
 
 # Handlers

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -83,7 +83,7 @@ defaultTarget = Target
 kernel :: Module
 kernel = Module kernelName [] [] $ Scope $ Map.fromList
   -- FIXME: this should really function as a synonym
-  [ (typeName, Just (DTerm KType) ::: TForAll (Binding Im (Just (U (TS.pack "ε"))) Nothing KInterface) (\ _E -> TRet (Sig _E []) KType)) ]
+  [ (typeName, Just (DTerm KType) ::: KType) ]
   where
   typeName = U (TS.pack "Type")
   kernelName = fromList [TS.pack "Kernel"]

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -387,7 +387,7 @@ elabInterfaceDef
   -> m (Maybe Def ::: Type)
 elabInterfaceDef _T constructors = trace "elabInterfaceDef" $ do
   cs <- for constructors $ runWithSpan $ \ (n ::: t) -> tracePretty n $ do
-    _T' <- elab $ check (switch (elabComp t) ::: KType)
+    _T' <- elab $ abstract (check (switch (elabComp t) ::: KType)) _T
     -- FIXME: check that the interface is a member of the sig.
     let _T'' = eval Nil mempty _T'
     pure $ n :=: Nothing ::: _T''

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -186,12 +186,14 @@ infix 1 |-
 --
 -- This is used to elaborate data constructors & effect operations, which receive the type/interface parameters as implicit parameters ahead of their own explicit ones.
 abstract :: Elab Quote -> Type -> Elab Quote
-abstract body = \case
-  TForAll t b -> do
-    level <- depth
-    b' <- t |- abstract body (b (free level))
-    pure $ QTForAll (quote level <$> set icit_ Im t) b'
-  _           -> body
+abstract body = go
+  where
+  go = \case
+    TForAll t b -> do
+      level <- depth
+      b' <- t |- go (b (free level))
+      pure $ QTForAll (quote level <$> set icit_ Im t) b'
+    _           -> body
 
 
 -- Expressions

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -312,15 +312,16 @@ elabClauses cs = Check $ \ _T -> trace "elabClauses" $ do
   d <- depth
   -- FIXME: I don’t see how this can be correct; the context will not hold a variable but rather a pattern of them.
   let _B' = _B (free d)
-  cs' <- for cs $ \ (S.Clause p b) -> elabPattern [] _A p (\ p' -> (tm <$> p',) <$> check (checkExpr b ::: _B'))
+  cs' <- for cs $ \ (S.Clause p b) -> elabPattern _A p (\ p' -> (tm <$> p',) <$> check (checkExpr b ::: _B'))
   pure $ QELam Ex cs'
 
 
 -- FIXME: check for unique variable names
 -- FIXME: get the sig from the argument type
-elabPattern :: [Value] -> Type -> S.Ann S.EffPattern -> (Pattern (Name ::: Type) -> Elab a) -> Elab a
-elabPattern sig = go
+elabPattern :: Type -> S.Ann S.EffPattern -> (Pattern (Name ::: Type) -> Elab a) -> Elab a
+elabPattern = go
   where
+  sig = []
   go _A (S.Ann s _ p) k = trace "elabPattern" $ setSpan s $ case p of
     S.PVal p -> goVal _A p k
     S.PEff n ps v -> do

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -182,6 +182,9 @@ Binding _ n _T |- b = trace "|-" $ do
 infix 1 |-
 
 
+-- | Elaborate a type abstracted over another type’s parameters.
+--
+-- This is used to elaborate data constructors & effect operations, which receive the type/interface parameters as implicit parameters ahead of their own explicit ones.
 abstract :: Elab Quote -> Type -> Elab Quote
 abstract body = \case
   TForAll t b -> do

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -299,7 +299,7 @@ force :: Synth a -> Synth a
 force e = Synth $ trace "force" $ do
   e' ::: _T <- synth e
   -- FIXME: should we check the signature? or can we rely on it already having been checked?
-  (_s, _T') <- expectRet "when forcing computation" _T
+  (_s, _T') <- expectComp "when forcing computation" _T
   pure $ e' ::: _T'
 
 
@@ -520,8 +520,8 @@ expectMatch pat exp s _T = maybe (mismatch s (Left exp) _T) pure (pat _T)
 expectQuantifier :: String -> Type -> Elab (Binding Value, Type -> Type)
 expectQuantifier = expectMatch (\case{ TForAll t b -> pure (t, b) ; _ -> Nothing }) "{_} -> _"
 
-expectRet :: String -> Type -> Elab (Sig Value, Type)
-expectRet = expectMatch (\case { TComp s t -> pure (s, t) ; _ -> Nothing }) "{_}"
+expectComp :: String -> Type -> Elab (Sig Value, Type)
+expectComp = expectMatch (\case { TComp s t -> pure (s, t) ; _ -> Nothing }) "{_}"
 
 
 -- Unification

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -321,10 +321,10 @@ elabClauses cs = Check $ \ _T -> trace "elabClauses" $ do
 elabPattern :: Type -> S.Ann S.EffPattern -> (Pattern (Name ::: Type) -> Elab a) -> Elab a
 elabPattern = go
   where
-  sig = []
   go _A (S.Ann s _ p) k = trace "elabPattern" $ setSpan s $ case p of
     S.PVal p -> goVal _A p k
     S.PEff n ps v -> do
+      let sig = []
       ElabContext{ module' = mod, graph } <- ask
       case lookupInSig n mod graph sig of
         Just (q ::: _T') -> do

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -317,15 +317,14 @@ elabClauses cs = Check $ \ _T -> trace "elabClauses" $ do
 
 
 -- FIXME: check for unique variable names
--- FIXME: get the sig from the argument type
 elabPattern :: Type -> S.Ann S.EffPattern -> (Pattern (Name ::: Type) -> Elab a) -> Elab a
 elabPattern = go
   where
   go _A (S.Ann s _ p) k = trace "elabPattern" $ setSpan s $ case p of
     S.PVal p -> goVal _A p k
     S.PEff n ps v -> do
-      let sig = []
       ElabContext{ module' = mod, graph } <- ask
+      (Sig _ sig, _) <- expectComp "when elaborating pattern" _A
       case lookupInSig n mod graph sig of
         Just (q ::: _T') -> do
           _T'' <- inst _T'

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -324,12 +324,12 @@ elabPattern = go
     S.PVal p -> goVal _A p k
     S.PEff n ps v -> do
       ElabContext{ module' = mod, graph } <- ask
-      (Sig _ sig, _) <- expectComp "when elaborating pattern" _A
+      (Sig _ sig, _A') <- expectComp "when elaborating pattern" _A
       case lookupInSig n mod graph sig of
         Just (q ::: _T') -> do
           _T'' <- inst _T'
           e <- view (sig_.effectVar_)
-          subpatterns _T'' ps $ \ _T ps' -> let t = TForAll (Binding Ex Nothing _T) (const (TComp (Sig e sig) _A)) in Binding Ex (Just v) t |- k (PEff q (fromList ps') (v ::: t))
+          subpatterns _T'' ps $ \ _T ps' -> let t = TForAll (Binding Ex Nothing _T) (const (TComp (Sig e sig) _A')) in Binding Ex (Just v) t |- k (PEff q (fromList ps') (v ::: t))
         _                -> freeVariable n
     -- FIXME: warn if using PAll with an empty sig.
     S.PAll n -> Binding Ex (Just n) _A |- k (PVar (n  ::: _A))

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -329,7 +329,7 @@ elabPattern = go
         Just (q ::: _T') -> do
           _T'' <- inst _T'
           e <- view (sig_.effectVar_)
-          subpatterns _T'' ps $ \ _T ps' -> k (PEff q (fromList ps') (v ::: TForAll (Binding Ex Nothing _T) (const (TComp (Sig e sig) _A))))
+          subpatterns _T'' ps $ \ _T ps' -> let t = TForAll (Binding Ex Nothing _T) (const (TComp (Sig e sig) _A)) in Binding Ex (Just v) t |- k (PEff q (fromList ps') (v ::: t))
         _                -> freeVariable n
     -- FIXME: warn if using PAll with an empty sig.
     S.PAll n -> Binding Ex (Just n) _A |- k (PVar (n  ::: _A))

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -244,11 +244,14 @@ elabComp (S.Ann s _ (S.Comp bs d b)) = Synth $ setSpan s . trace "elabComp" $ fo
     b' ::: _ <- fmap (uncurry eval env) t' |- b
     pure $ QTForAll t' b' ::: KType)
   (do
-    d' <- traverse (traverse (check . (::: KInterface) . elabSig)) d
     b' <- check (checkExpr b ::: KType)
-    level <- depth
-    e <- views (sig_.effectVar_) (quote level)
-    pure $ QTComp (Sig e (fromMaybe [] d')) b' ::: KType)
+    case d of
+      Just d -> do
+        d' <- traverse (check . (::: KInterface) . elabSig) d
+        level <- depth
+        e <- views (sig_.effectVar_) (quote level)
+        pure $ QTComp (Sig e d') b' ::: KType
+      Nothing -> pure (b' ::: KType))
   (elabBinding =<< bs)
 
 -- comp type has a list of bindings, maybe a list of constraints, and a return type; turn the latter two into a QTComp and the former into a series of QTForAlls

--- a/src/Facet/Eval.hs
+++ b/src/Facet/Eval.hs
@@ -26,7 +26,7 @@ eval = \case
         -> eval $ v $$* sp'
       _ -> pure $ VNe (h :$ sp')
 
-  TSusp (TRet (Sig _ []) v) -> eval v
+  TComp (Sig _ []) v -> eval v
 
   EOp op -> Eval $ \ h -> h op
 

--- a/src/Facet/Graph.hs
+++ b/src/Facet/Graph.hs
@@ -57,7 +57,7 @@ lookupWith lookup (m:.:n) mod@Module{ name } graph
   <|> guard (m == Nil) *> asum (lookup n . snd <$> getGraph graph)
   <|> guard (m /= Nil) *> (lookupM m graph >>= lookup n . snd)
 
-lookupQ :: (Alternative m, Monad m) => Q Name -> Module -> Graph -> m (Q Name :=: Maybe Def ::: Comp)
+lookupQ :: (Alternative m, Monad m) => Q Name -> Module -> Graph -> m (Q Name :=: Maybe Def ::: Type)
 lookupQ = lookupWith lookupD
 
 -- FIXME: enrich this with source references for each

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -41,7 +41,7 @@ import           Facet.Notice.Elab
 import           Facet.Notice.Parser
 import           Facet.Parser as Parser
 import           Facet.Pretty
-import           Facet.Print as Print hiding (Comp, meta)
+import           Facet.Print as Print hiding (meta)
 import           Facet.REPL.Parser
 import           Facet.Source (Source(..), sourceFromString)
 import           Facet.Span (Span)

--- a/test/Facet/Core/Test.hs
+++ b/test/Facet/Core/Test.hs
@@ -14,5 +14,5 @@ tests :: IO Bool
 tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
-  let init = QTSusp (QComp [Binding Im (Just (U "ε")) Nothing QKInterface, Binding Im (Just (U "A")) Nothing QKType, Binding Ex (Just (U "x")) Nothing (QVar (Free 0)) ] (Sig (QVar (Free 2)) []) (QVar (Free 1)))
+  let init = QTForAll (Binding Im (Just (U "ε")) QKInterface) (QTForAll (Binding Im (Just (U "A")) QKType) (QTForAll (Binding Ex (Just (U "x")) (QVar (Free 0))) (QTComp (Sig (QVar (Free 2)) []) (QVar (Free 1)))))
   quote 0 (eval Nil mempty init) === init


### PR DESCRIPTION
This PR goes back to a distinct notion of computation types. Note that not everything here works—effect patterns need work, and a bunch of the std lib needs updating. Further, note that this doesn’t actually provide the intended semantics yet: it requires a lot more `!`s than we really want, and that really hinders the usability of combinators such as `;`. Finally, we still have the problem (extant, tho much harder to see due to other issues that this PR resolves, on `master`) that we never perform substitution and so metavariables are left in terms.

All of this is left as work for future PRs.