### PR TITLE
Eliminate the conflation of CBPV thunks and Frank–style suspended computations

### DIFF
--- a/lib/Data/Bool.facet
+++ b/lib/Data/Bool.facet
@@ -1,5 +1,7 @@
 module Data.Bool : Module
 
+import Data.Unit
+
 data Bool : Type
 { false : Bool
 , true : Bool }
@@ -18,9 +20,9 @@ _ || _ : Bool -> Bool -> Bool
 { (false) -> { x -> x }
 , _       -> { _ -> true } }
 
-if : { A : Type } -> (c : Bool) -> (t : {A}) -> (e : {A}) -> A
+if : { A : Type } -> (c : Bool) -> (t : Unit -> A) -> (e : Unit -> A) -> A
 { bool e t c }
 
-bool : { A : Type } -> (e : {A}) -> (t : {A}) -> Bool -> A
+bool : { A : Type } -> (e : Unit -> A) -> (t : Unit -> A) -> Bool -> A
 { (true)  -> t!
 , (false) -> e! }

--- a/lib/Data/Unit.facet
+++ b/lib/Data/Unit.facet
@@ -2,3 +2,6 @@ module Data.Unit : Module
 
 data Unit : Type
 { unit : Unit }
+
+force : { A : Type } -> (c : Unit -> A) -> A
+{ c unit }

--- a/lib/Data/Unit.facet
+++ b/lib/Data/Unit.facet
@@ -5,3 +5,6 @@ data Unit : Type
 
 force : { A : Type } -> (c : Unit -> A) -> A
 { c unit }
+
+_ ! : { A : Type } -> (Unit -> A) -> A
+{ force }

--- a/lib/Effect/Choose.facet
+++ b/lib/Effect/Choose.facet
@@ -1,10 +1,11 @@
 module Effect.Choose : Module
 
 import Data.Bool
+import Data.Unit
 
 interface Choose : Interface
 { choose : Bool }
 
 _ | _ [left-assoc]
-: { A : Type } -> (l : { A }) -> (r : { A }) -> [Choose] A
+: { A : Type } -> (l : Unit -> A) -> (r : Unit -> A) -> [Choose] A
 { if choose r l }

--- a/lib/Effect/Empty.facet
+++ b/lib/Effect/Empty.facet
@@ -1,10 +1,11 @@
 module Effect.Empty : Module
 
 import Data.Bool
+import Data.Function
 import Data.Unit
 
 interface Empty : Interface
 { empty : { A : Type } -> A }
 
 guard : (c : Bool) -> [Empty] Unit
-{ if c { unit } { empty } }
+{ if c id { (unit) -> empty } }

--- a/src/Facet/Core/Term.hs
+++ b/src/Facet/Core/Term.hs
@@ -57,7 +57,6 @@ data Expr
   | XInst Expr T.TExpr
   | XLam [(Pattern Name, Expr)]
   | XApp Expr Expr
-  | XThunk Expr
   | XCon (Q Name) (Snoc T.TExpr) (Snoc Expr)
   | XString Text
   | XOp (Q Name) (Snoc T.TExpr) (Snoc Expr)

--- a/src/Facet/Core/Term.hs
+++ b/src/Facet/Core/Term.hs
@@ -58,7 +58,6 @@ data Expr
   | XLam [(Pattern Name, Expr)]
   | XApp Expr Expr
   | XThunk Expr
-  | XForce Expr
   | XCon (Q Name) (Snoc T.TExpr) (Snoc Expr)
   | XString Text
   | XOp (Q Name) (Snoc T.TExpr) (Snoc Expr)

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -338,8 +338,6 @@ unify t1 t2 = type' t1 t2
     -- FIXME: this must unify the signatures
     (VArrow _ _ a1 b1, VArrow _ _ a2 b2)                     -> type' a1 a2 >> type' b1 b2
     (VArrow{}, _)                                            -> nope
-    (VSusp t1, VSusp t2)                                     -> type' t1 t2
-    (VSusp{}, _)                                             -> nope
     (VRet s1 t1, VRet s2 t2)                                 -> sig s1 s2 >> type' t1 t2
     (VRet _ t1, t2)                                          -> type' t1 t2
     (t1, VRet _ t2)                                          -> type' t1 t2

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -148,7 +148,6 @@ synthExpr (S.Ann s _ e) = mapSynth (pushSpan s) $ case e of
   S.String s -> string s
   S.Hole{}   -> nope
   S.Lam{}    -> nope
-  S.Force{}  -> nope
   where
   nope = Synth $ couldNotSynthesize (show e)
 
@@ -156,7 +155,6 @@ checkExpr :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => S.Ann S.Exp
 checkExpr expr@(S.Ann s _ e) = mapCheck (pushSpan s) $ case e of
   S.Hole  n  -> hole n
   S.Lam cs   -> lam (map (\ (S.Clause p b) -> (bindPattern p, checkExpr b)) cs)
-  S.Force{}  -> synth
   S.Var{}    -> synth
   S.App{}    -> synth
   S.As{}     -> synth

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -164,11 +164,11 @@ checkExpr expr@(S.Ann s _ e) = mapCheck (pushSpan s) $ case e of
 
 
 -- FIXME: check for unique variable names
-bindPattern :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => S.Ann S.EffPattern -> Bind m (Pattern Name)
+bindPattern :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => S.Ann S.Pattern -> Bind m (Pattern Name)
 bindPattern = go where
   go = withSpanB $ \case
-    S.PVal p      -> Bind $ \ q _T -> bind (PVal <$> goVal p ::: (q, maybe _T snd (unRet _T)))
-    S.PEff n ps v -> effP n (map goVal ps) v
+    S.PVal p -> Bind $ \ q _T -> bind (PVal <$> goVal p ::: (q, maybe _T snd (unRet _T)))
+    S.PEff p -> withSpanB (\ (S.POp n ps v) -> effP n (map goVal ps) v) p
 
   goVal = withSpanB $ \case
     S.PWildcard -> wildcardP

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -157,7 +157,7 @@ checkExpr :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => S.Ann S.Exp
 checkExpr expr@(S.Ann s _ e) = mapCheck (pushSpan s) $ case e of
   S.Hole  n  -> hole n
   S.Lam cs   -> lam (map (\ (S.Clause p b) -> (bindPattern p, checkExpr b)) cs)
-  S.Thunk e  -> thunk (checkExpr e)
+  S.Thunk{}  -> synth
   S.Force{}  -> synth
   S.Var{}    -> synth
   S.App{}    -> synth

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -148,7 +148,6 @@ synthExpr (S.Ann s _ e) = mapSynth (pushSpan s) $ case e of
   S.String s -> string s
   S.Hole{}   -> nope
   S.Lam{}    -> nope
-  S.Thunk{}  -> nope
   S.Force{}  -> nope
   where
   nope = Synth $ couldNotSynthesize (show e)
@@ -157,7 +156,6 @@ checkExpr :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => S.Ann S.Exp
 checkExpr expr@(S.Ann s _ e) = mapCheck (pushSpan s) $ case e of
   S.Hole  n  -> hole n
   S.Lam cs   -> lam (map (\ (S.Clause p b) -> (bindPattern p, checkExpr b)) cs)
-  S.Thunk{}  -> synth
   S.Force{}  -> synth
   S.Var{}    -> synth
   S.App{}    -> synth

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -5,7 +5,6 @@ module Facet.Elab.Term
 , var
 , tlam
 , lam
-, thunk
 , force
 , string
   -- * Pattern combinators
@@ -85,12 +84,6 @@ lam cs = Check $ \ _T -> do
   (_A, _B) <- expectTacitFunction "when checking clause" _T
   XLam <$> traverse (\ (p, b) -> check (bind (p ::: _A) b ::: _B)) cs
 
-
-thunk :: (HasCallStack, Has (Throw Err) sig m) => Check m a -> Check m a
-thunk e = Check $ \ _T -> do
-  _T' <- metavar <$> meta VType
-  unify _T (VSusp _T')
-  check (e ::: _T')
 
 force :: (HasCallStack, Has (Throw Err) sig m) => Synth m a -> Synth m a
 force e = Synth $ do

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -5,7 +5,6 @@ module Facet.Elab.Term
 , var
 , tlam
 , lam
-, force
 , string
   -- * Pattern combinators
 , wildcardP
@@ -83,15 +82,6 @@ lam :: (HasCallStack, Has (Throw Err) sig m) => [(Bind m (Pattern Name), Check m
 lam cs = Check $ \ _T -> do
   (_A, _B) <- expectTacitFunction "when checking clause" _T
   XLam <$> traverse (\ (p, b) -> check (bind (p ::: _A) b ::: _B)) cs
-
-
-force :: (HasCallStack, Has (Throw Err) sig m) => Synth m a -> Synth m a
-force e = Synth $ do
-  e' ::: _T <- synth e
-  -- FIXME: should we check the signature? or can we rely on it already having been checked?
-  _T' <- metavar <$> meta VType
-  unify _T (VSusp _T')
-  pure $ e' ::: _T'
 
 
 string :: Text -> Synth m Expr

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -149,7 +149,7 @@ synthExpr (S.Ann s _ e) = mapSynth (pushSpan s) $ case e of
   S.Hole{}   -> nope
   S.Lam{}    -> nope
   S.Thunk{}  -> nope
-  S.Force e  -> force (synthExpr e)
+  S.Force{}  -> nope
   where
   nope = Synth $ couldNotSynthesize (show e)
 

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -85,7 +85,6 @@ synthType (S.Ann s _ e) = mapSynth (pushSpan s) $ case e of
   S.TString         -> _String
   S.TForAll n t b   -> forAll (n ::: checkType t) (checkType b)
   S.TArrow  n q a b -> (n ::: ((maybe Many interpretMul q,) <$> checkType a)) --> checkType b
-  S.TSusp t         -> susp (checkType t)
   S.TRet s t        -> ret (map checkInterface s) (checkType t)
   S.TApp f a        -> app TApp (synthType f) (checkType a)
   where

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -7,7 +7,6 @@ module Facet.Elab.Type
 , _String
 , forAll
 , (-->)
-, susp
 , synthType
 , checkType
 ) where
@@ -62,12 +61,6 @@ forAll (n ::: t) b = Synth $ do
 
 infixr 1 -->
 
-
-susp :: Algebra sig m => Check m TExpr -> Synth m TExpr
-susp t = Synth $ do
-  t' <- check (t ::: VType)
-  -- FIXME: classify types by universe (value/computation) and check that this is a computation type being suspended
-  pure $ TSusp t' ::: VType
 
 ret :: Algebra sig m => [Check m TExpr] -> Check m TExpr -> Synth m TExpr
 ret s t = Synth $ do

--- a/src/Facet/Eval.hs
+++ b/src/Facet/Eval.hs
@@ -63,9 +63,6 @@ eval = runReader Nil . go
       VLam _ h k <- go f
       extendHandler h (go a) >>= lift . k
     XThunk b         -> asks (\ env -> VThunk (runReader env (go b)))
-    XForce t         -> do
-      VThunk b <- go t
-      lift b
     XCon n _ fs      -> VCon n <$> traverse go fs
     XString s        -> pure $ VString s
     XOp n _ sp       -> do

--- a/src/Facet/Parser.hs
+++ b/src/Facet/Parser.hs
@@ -182,6 +182,7 @@ tvar :: (Has Parser sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenPar
 tvar = anned (S.TVar <$> qname tname)
 
 
+-- FIXME: parse {A} as a synonym for Unit -> A. Better yet, implement mixfix type operators & type synonyms, and define it as a synonym in Data.Unit.
 suspendedCompType :: (Has Parser sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenParsing p) => p (S.Ann S.Type)
 suspendedCompType = anned $ braces (S.TSusp <$> type')
 

--- a/src/Facet/Parser.hs
+++ b/src/Facet/Parser.hs
@@ -49,6 +49,7 @@ import           Text.Parser.Token.Highlight as Highlight
 
 -- FIXME: allow operators to be introduced and scoped locally
 -- FIXME: we can’t parse without knowing operators defined elsewhere
+-- FIXME: parse {A} as a synonym for Unit -> A. Better yet, implement mixfix type operators & type synonyms, and define it as a synonym in Data.Unit.
 
 whole :: TokenParsing p => p a -> p a
 whole p = whiteSpace *> p <* eof
@@ -144,7 +145,6 @@ monotypeTable =
     , atom (token (anned (S.TString    <$ string "String")))
       -- FIXME: holes in types
     , atom tvar
-    , atom (try suspendedCompType)
     ]
   ]
 
@@ -181,10 +181,6 @@ monotype = build monotypeTable $ parens type'
 tvar :: (Has Parser sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenParsing p) => p (S.Ann S.Type)
 tvar = anned (S.TVar <$> qname tname)
 
-
--- FIXME: parse {A} as a synonym for Unit -> A. Better yet, implement mixfix type operators & type synonyms, and define it as a synonym in Data.Unit.
-suspendedCompType :: (Has Parser sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenParsing p) => p (S.Ann S.Type)
-suspendedCompType = anned $ braces (S.TSusp <$> type')
 
 signature :: (Has Parser sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenParsing p) => p [S.Ann S.Interface]
 signature = brackets (commaSep delta) <?> "signature"

--- a/src/Facet/Parser.hs
+++ b/src/Facet/Parser.hs
@@ -203,9 +203,6 @@ exprTable =
   -- FIXME: better yet, generalize operators to allow different syntactic types on either side (following the associativity)
   [ [ ascription ]
   , [ parseOperator (N.Infix mempty, N.L, foldl1 (S.annBinary S.App)) ]
-  -- FIXME: model this as application to unit instead
-  -- FIXME: can we parse () as a library-definable symbol? nullfix, maybe?
-  , [ parseOperator (N.Postfix (pack "!"), N.L, S.annUnary S.Force . head) ]
   , [ atom thunk, atom hole, atom evar, atom (token (anned (runUnspaced (S.String <$> stringLiteral)))) ]
   ]
 

--- a/src/Facet/Parser.hs
+++ b/src/Facet/Parser.hs
@@ -213,7 +213,7 @@ ascription _self next = anned (S.As <$> try (next <* colon) <*> type') <|> next
 
 thunk :: (Has Parser sig p, Has (State [Operator (S.Ann S.Expr)]) sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenParsing p) => p (S.Ann S.Expr)
 -- NB: We parse sepBy1 and the empty case separately so that it doesn’t succeed at matching 0 clauses and then expect a closing brace when it sees a nullary computation
-thunk = anned (braces (S.Lam <$> sepBy1 clause comma <|> S.Thunk <$> expr <|> pure (S.Lam [])))
+thunk = anned (braces (S.Lam <$> sepBy1 clause comma <|> {-S.Thunk <$> expr <|>-} pure (S.Lam [])))
 
 clause :: (Has Parser sig p, Has (State [Operator (S.Ann S.Expr)]) sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenParsing p) => p S.Clause
 clause = S.Clause <$> try (compPattern <* arrow) <*> expr <?> "clause"

--- a/src/Facet/Parser.hs
+++ b/src/Facet/Parser.hs
@@ -245,10 +245,10 @@ valuePattern = choice
   , try (parens (anned (S.PCon <$> qname ename <*> many valuePattern)))
   ] <?> "pattern"
 
-compPattern :: (Has Parser sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenParsing p) => p (S.Ann S.EffPattern)
+compPattern :: (Has Parser sig p, Has (Writer (Snoc (Span, S.Comment))) sig p, TokenParsing p) => p (S.Ann S.Pattern)
 compPattern = choice
   [ anned (S.PVal <$> valuePattern)
-  , try (brackets (anned (S.PEff <$> qname ename <*> many valuePattern <* symbolic ';' <*> (ename <|> N.__ <$ wildcard))))
+  , anned (S.PEff <$> try (brackets (anned (S.POp <$> qname ename <*> many valuePattern <* symbolic ';' <*> (ename <|> N.__ <$ wildcard)))))
   ] <?> "pattern"
 
 

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -157,7 +157,6 @@ printTExpr Options{ qname, instantiation } = go
     C.TForAll      n    t b -> braces (ann (intro n d ::: go env t)) --> go (env :> intro n d) b
     C.TArrow Nothing  q a b -> mult q (go env a) --> go env b
     C.TArrow (Just n) q a b -> parens (ann (intro n d ::: mult q (go env a))) --> go env b
-    C.TSusp t               -> braces (go env t)
     C.TRet [] t             -> go env t
     C.TRet s t              -> sig s <+> go env t
     C.TInst f t             -> group (go env f) `instantiation` group (braces (go env t))

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -181,7 +181,6 @@ printExpr opts@Options{ qname, instantiation } = go
     C.XInst e t        -> go env e `instantiation` braces (printTExpr opts env t)
     C.XLam cs          -> comp (commaSep (map (clause env) cs))
     C.XApp f a         -> go env f $$ go env a
-    C.XThunk b         -> comp (go env b)
     C.XCon n t p       -> foldl' instantiation (qvar n) (group . braces . printTExpr opts env <$> t) $$* (group . go env <$> p)
     C.XOp n t p        -> foldl' instantiation (qvar n) (group . braces . printTExpr opts env <$> t) $$* (group . go env <$> p)
     C.XString s        -> annotate Lit $ pretty (show s)

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -182,7 +182,6 @@ printExpr opts@Options{ qname, instantiation } = go
     C.XLam cs          -> comp (commaSep (map (clause env) cs))
     C.XApp f a         -> go env f $$ go env a
     C.XThunk b         -> comp (go env b)
-    C.XForce b         -> go env b <> op (pretty '!') -- FIXME: figure out a precedence for this
     C.XCon n t p       -> foldl' instantiation (qvar n) (group . braces . printTExpr opts env <$> t) $$* (group . go env <$> p)
     C.XOp n t p        -> foldl' instantiation (qvar n) (group . braces . printTExpr opts env <$> t) $$* (group . go env <$> p)
     C.XString s        -> annotate Lit $ pretty (show s)

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -58,7 +58,6 @@ data Expr
   = Var (Q Name)
   | Hole Name
   | Lam [Clause]
-  | Force (Ann Expr)
   | App (Ann Expr) (Ann Expr)
   | As (Ann Expr) (Ann Type)
   | String Text

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -58,7 +58,6 @@ data Expr
   = Var (Q Name)
   | Hole Name
   | Lam [Clause]
-  | Thunk (Ann Expr)
   | Force (Ann Expr)
   | App (Ann Expr) (Ann Expr)
   | As (Ann Expr) (Ann Type)

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -44,7 +44,6 @@ data Type
   | TString
   | TForAll Name (Ann Type) (Ann Type)
   | TArrow (Maybe Name) (Maybe Mul) (Ann Type) (Ann Type)
-  | TSusp (Ann Type)
   | TRet [Ann Interface] (Ann Type)
   | TApp (Ann Type) (Ann Type)
   deriving (Eq, Show)

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -8,6 +8,7 @@ module Facet.Surface
 , Interface(..)
 , Clause(..)
   -- * Patterns
+, Pattern(..)
 , ValPattern(..)
 , EffPattern(..)
   -- * Declarations
@@ -68,11 +69,16 @@ data Interface = Interface (Ann (Q Name)) (Snoc (Ann Type))
   deriving (Eq, Show)
 
 
-data Clause = Clause (Ann EffPattern) (Ann Expr)
+data Clause = Clause (Ann Pattern) (Ann Expr)
   deriving (Eq, Show)
 
 
 -- Patterns
+
+data Pattern
+  = PVal (Ann ValPattern)
+  | PEff (Ann EffPattern)
+  deriving (Eq, Show)
 
 data ValPattern
   = PWildcard
@@ -80,10 +86,7 @@ data ValPattern
   | PCon (Q Name) [Ann ValPattern]
   deriving (Eq, Show)
 
-
-data EffPattern
-  = PEff (Q Name) [Ann ValPattern] Name
-  | PVal (Ann ValPattern)
+data EffPattern = POp (Q Name) [Ann ValPattern] Name
   deriving (Eq, Show)
 
 


### PR DESCRIPTION
I misidentified Frank’s suspended computation types with CBPV’s thunks, the latter of which embed computations (lambdas, sequencing, forces) into values. There is definitely some similarity, but they’re distinct; I currently believe CBPV’s thunks are better thought of as a logical shift between the value and computation typing judgements.

This conflation made it harder to understand how to make correct use of thunks and forcing in the evaluator, since these could also occur in surface syntax. By viewing thunks/forcing as a finer-grained interpretation of higher-level constructs such as (TBD) syntax sugar for introducing and eliminating functions from `Unit`, we obtain a clearer picture of the role they play w.r.t. Facet’s elaborator (approximately none, at least as yet) and evaluator (part of the value domain), and potentially gain some insight into how we can structure the language of types to reflect what we need of this.