### PR TITLE
Prune loads with failed dependencies

### DIFF
--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -97,7 +97,7 @@ reloadModules = do
     targetHeads <- traverse (loadModuleHeader searchPaths . Right) (toList targets)
     rethrowGraphErrors [] $ loadOrder (fmap toNode . loadModuleHeader searchPaths . Right) (map toNode targetHeads)
   let nModules = length modules
-  results <- evalFresh 1 $ for modules $ \ (name, path, src, imports) -> do
+  results <- evalFresh 1 $ for modules $ \ (ModuleHeader name path src imports) -> do
     i <- fresh
     outputDocLn $ annotate Progress (brackets (ratio i nModules)) <+> nest 2 (group (fillSep [ pretty "Loading", prettyMName name ]))
 
@@ -110,7 +110,7 @@ reloadModules = do
   outputDocLn (fillSep [status, reflow "modules loaded."])
   where
   ratio n d = pretty n <+> pretty "of" <+> pretty d
-  toNode (ModuleHeader n path source imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (n, path, source, imports')
+  toNode h@(ModuleHeader n _ _ imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (h{ imports = imports' } :: ModuleHeader MName)
 
 data ModuleHeader a = ModuleHeader
   { moduleName :: MName

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -35,7 +35,7 @@ import qualified Data.Text as TS
 import           Data.Traversable (for)
 import           Facet.Carrier.Parser.Church
 import qualified Facet.Carrier.Throw.Inject as I
-import           Facet.Core.Module as Module hiding (Import(name), imports, imports_)
+import           Facet.Core.Module hiding (Import(name), imports, imports_)
 import           Facet.Effect.Readline
 import           Facet.Effect.Write
 import qualified Facet.Elab.Term as Elab
@@ -147,7 +147,7 @@ loadModuleHeader searchPaths target = do
 
 loadModule :: Has (Output :+: State Options :+: Throw (Notice.Notice (Doc Style)) :+: Write (Notice.Notice (Doc Style))) sig m => Graph -> ModuleHeader Module -> m Module
 loadModule graph (ModuleHeader _ src imports) = do
-  let ops = foldMap (\ m -> map (\ (op, assoc) -> (Module.name m, op, assoc)) (operators m)) imports
+  let ops = foldMap (\ m -> map (\ (op, assoc) -> (name m, op, assoc)) (operators m)) imports
   m <- rethrowParseErrors @Style (runParserWithSource src (runFacet (map makeOperator ops) (whole module')))
   opts <- get
   rethrowElabWarnings . rethrowElabErrors opts . runReader graph . runReader src $ Elab.elabModule m

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -143,7 +143,7 @@ loadModuleHeader searchPaths target = do
   (name', is) <- rethrowParseErrors @Style (runParserWithSource src (runFacet [] (whiteSpace *> moduleHeader)))
   pure (ModuleHeader name' path src (map (Import.name . S.out) is))
 
-loadModule :: Has (Output :+: State Options :+: State Target :+: Throw (Notice.Notice (Doc Style)) :+: Write (Notice.Notice (Doc Style))) sig m => Graph -> ModuleHeader Module -> m (FilePath, Module)
+loadModule :: Has (Output :+: State Options :+: Throw (Notice.Notice (Doc Style)) :+: Write (Notice.Notice (Doc Style))) sig m => Graph -> ModuleHeader Module -> m (FilePath, Module)
 loadModule graph (ModuleHeader name path src imports) = do
   let ops = foldMap (map (\ (op, assoc) -> (name, op, assoc)) . operators) imports
   m <- rethrowParseErrors @Style (runParserWithSource src (runFacet (map makeOperator ops) (whole module')))

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -128,7 +128,7 @@ loadModule name path src imports = do
   m <- rethrowParseErrors @Style (runParserWithSource src (runFacet (map makeOperator ops) (whole module')))
   opts <- get
   m <- rethrowElabWarnings . rethrowElabErrors opts . runReader graph . runReader src $ Elab.elabModule m
-  modules_.at name .= Just (Just path, m)
+  modules_.at name .= Just (Just path, Just m)
   pure m
 
 resolveName :: (Has (Throw (Notice.Notice (Doc Style))) sig m, MonadIO m) => [FilePath] -> MName -> m FilePath

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -9,6 +9,7 @@ module Facet.Driver
   -- * Module loading
 , reloadModules
 , ModuleHeader(..)
+, imports_
 , headerNode
 , loadModuleHeader
 , loadModule
@@ -24,7 +25,7 @@ import           Control.Carrier.Reader
 import           Control.Effect.Error
 import           Control.Effect.Lens (use, uses, (.=))
 import           Control.Effect.State
-import           Control.Lens (Lens', at, lens)
+import           Control.Lens (Lens, Lens', at, lens)
 import           Control.Monad.IO.Class
 import           Data.Foldable (toList)
 import           Data.Maybe (catMaybes)
@@ -33,7 +34,7 @@ import qualified Data.Text as TS
 import           Data.Traversable (for)
 import           Facet.Carrier.Parser.Church
 import qualified Facet.Carrier.Throw.Inject as I
-import           Facet.Core.Module
+import           Facet.Core.Module hiding (imports, imports_)
 import           Facet.Effect.Readline
 import           Facet.Effect.Write
 import qualified Facet.Elab.Term as Elab
@@ -121,6 +122,9 @@ data ModuleHeader a = ModuleHeader
   , imports    :: [a]
   }
   deriving (Foldable, Functor, Traversable)
+
+imports_ :: Lens (ModuleHeader a) (ModuleHeader b) [a] [b]
+imports_ = lens imports (\ h imports -> h{ imports })
 
 headerNode :: ModuleHeader MName -> Node (ModuleHeader MName)
 headerNode h@(ModuleHeader n _ _ imports) = Node n imports h

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -101,7 +101,6 @@ reloadModules = do
   let nModules = length modules
   results <- for (zip [1..] modules) $ \ (i, h@(ModuleHeader name src _)) -> do
     graph <- use modules_
-    -- FIXME: skip gracefully (maybe print a message) if any of its imports are unavailable due to earlier errors
     let loaded = traverse (\ name -> graph^.at name >>= snd) h
     case loaded of
       Just loaded -> (Just <$> do

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -124,7 +124,7 @@ loadModuleHeader searchPaths target = do
 loadModule :: Has (Output :+: State Options :+: State Target :+: Throw (Notice.Notice (Doc Style)) :+: Write (Notice.Notice (Doc Style))) sig m => MName -> FilePath -> Source -> [MName] -> m Module
 loadModule name path src imports = do
   graph <- use modules_
-  let ops = foldMap (\ name -> lookupM name graph >>= map (\ (op, assoc) -> (name, op, assoc)) . operators . snd) imports
+  let ops = foldMap (\ name -> lookupM name graph >>= maybe [] pure . snd >>= map (\ (op, assoc) -> (name, op, assoc)) . operators) imports
   m <- rethrowParseErrors @Style (runParserWithSource src (runFacet (map makeOperator ops) (whole module')))
   opts <- get
   m <- rethrowElabWarnings . rethrowElabErrors opts . runReader graph . runReader src $ Elab.elabModule m

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -113,6 +113,7 @@ reloadModules = do
   toNode (ModuleHeader n path source imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (n, path, source, imports')
 
 data ModuleHeader a = ModuleHeader MName FilePath Source [a]
+  deriving (Foldable, Functor, Traversable)
 
 loadModuleHeader :: (Has (Output :+: Throw (Notice.Notice (Doc Style))) sig m, MonadIO m) => [FilePath] -> Either FilePath MName -> m (ModuleHeader (S.Ann S.Import))
 loadModuleHeader searchPaths target = do

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -106,11 +106,13 @@ reloadModules = do
     graph <- use modules_
     -- FIXME: skip gracefully (maybe print a message) if any of its imports are unavailable due to earlier errors
     let loaded = traverse (\ name -> graph^.at name >>= snd) imports
-    for loaded $ \ loaded -> (do
-      (path, m) <- loadModule graph h{ imports = loaded }
-      modules_.at name .= Just (Just path, Just m)
-      pure (Just m))
-      `catchError` \ err -> Nothing <$ outputDocLn (prettyNotice err)
+    case loaded of
+      Just loaded -> (do
+        (path, m) <- loadModule graph h{ imports = loaded }
+        modules_.at name .= Just (Just path, Just m)
+        pure (Just m))
+        `catchError` \ err -> Nothing <$ outputDocLn (prettyNotice err)
+      Nothing -> pure Nothing
   let nSuccess = length (catMaybes results)
       status
         | nModules == nSuccess = annotate Success (pretty nModules)

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -93,6 +93,7 @@ kernel = Module kernelName [] [] $ Scope mempty
 reloadModules :: (Has (Error (Notice.Notice (Doc Style)) :+: Output :+: State Options :+: State Target :+: Write (Notice.Notice (Doc Style))) sig m, MonadIO m) => m ()
 reloadModules = do
   searchPaths <- uses searchPaths_ toList
+  modules_ .= singleton Nothing kernel
   modules <- targets_ ~> \ targets -> do
     -- FIXME: remove stale modules
     -- FIXME: only reload changed modules

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -112,9 +112,9 @@ reloadModules = do
   ratio n d = pretty n <+> pretty "of" <+> pretty d
   toNode (ModuleHeader n path source imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (n, path, source, imports')
 
-data ModuleHeader = ModuleHeader MName FilePath Source [S.Ann S.Import]
+data ModuleHeader a = ModuleHeader MName FilePath Source [a]
 
-loadModuleHeader :: (Has (Output :+: Throw (Notice.Notice (Doc Style))) sig m, MonadIO m) => [FilePath] -> Either FilePath MName -> m ModuleHeader
+loadModuleHeader :: (Has (Output :+: Throw (Notice.Notice (Doc Style))) sig m, MonadIO m) => [FilePath] -> Either FilePath MName -> m (ModuleHeader (S.Ann S.Import))
 loadModuleHeader searchPaths target = do
   path <- case target of
     Left path  -> pure path

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -95,6 +95,7 @@ reloadModules = do
   searchPaths <- uses searchPaths_ toList
   modules <- targets_ ~> \ targets -> do
     -- FIXME: remove stale modules
+    -- FIXME: only reload changed modules
     -- FIXME: failed module header parses shouldn’t invalidate everything.
     targetHeads <- traverse (loadModuleHeader searchPaths . Right) (toList targets)
     rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) (map headerNode targetHeads)

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -112,7 +112,12 @@ reloadModules = do
   ratio n d = pretty n <+> pretty "of" <+> pretty d
   toNode (ModuleHeader n path source imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (n, path, source, imports')
 
-data ModuleHeader a = ModuleHeader MName FilePath Source [a]
+data ModuleHeader a = ModuleHeader
+  { moduleName :: MName
+  , path       :: FilePath
+  , source     :: Source
+  , imports    :: [a]
+  }
   deriving (Foldable, Functor, Traversable)
 
 loadModuleHeader :: (Has (Output :+: Throw (Notice.Notice (Doc Style))) sig m, MonadIO m) => [FilePath] -> Either FilePath MName -> m (ModuleHeader (S.Ann S.Import))

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -35,7 +35,7 @@ import qualified Data.Text as TS
 import           Data.Traversable (for)
 import           Facet.Carrier.Parser.Church
 import qualified Facet.Carrier.Throw.Inject as I
-import           Facet.Core.Module hiding (imports, imports_)
+import           Facet.Core.Module as Module hiding (Import(name), imports, imports_)
 import           Facet.Effect.Readline
 import           Facet.Effect.Write
 import qualified Facet.Elab.Term as Elab
@@ -146,8 +146,8 @@ loadModuleHeader searchPaths target = do
   pure (ModuleHeader name' src (map (Import.name . S.out) is))
 
 loadModule :: Has (Output :+: State Options :+: Throw (Notice.Notice (Doc Style)) :+: Write (Notice.Notice (Doc Style))) sig m => Graph -> ModuleHeader Module -> m Module
-loadModule graph (ModuleHeader name src imports) = do
-  let ops = foldMap (map (\ (op, assoc) -> (name, op, assoc)) . operators) imports
+loadModule graph (ModuleHeader _ src imports) = do
+  let ops = foldMap (\ m -> map (\ (op, assoc) -> (Module.name m, op, assoc)) (operators m)) imports
   m <- rethrowParseErrors @Style (runParserWithSource src (runFacet (map makeOperator ops) (whole module')))
   opts <- get
   rethrowElabWarnings . rethrowElabErrors opts . runReader graph . runReader src $ Elab.elabModule m

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -100,7 +100,6 @@ reloadModules = do
     rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) (map headerNode targetHeads)
   let nModules = length modules
   results <- for (zip [1..] modules) $ \ (i, h@(ModuleHeader name src _)) -> do
-
     graph <- use modules_
     -- FIXME: skip gracefully (maybe print a message) if any of its imports are unavailable due to earlier errors
     let loaded = traverse (\ name -> graph^.at name >>= snd) h

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -8,6 +8,7 @@ module Facet.Driver
 , kernel
   -- * Module loading
 , reloadModules
+, ModuleHeader(..)
 , loadModuleHeader
 , loadModule
 , resolveName
@@ -110,6 +111,8 @@ reloadModules = do
   where
   ratio n d = pretty n <+> pretty "of" <+> pretty d
   toNode (n, path, source, imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (n, path, source, imports')
+
+data ModuleHeader = ModuleHeader MName FilePath Source [S.Ann S.Import]
 
 loadModuleHeader :: (Has (Output :+: Throw (Notice.Notice (Doc Style))) sig m, MonadIO m) => [FilePath] -> Either FilePath MName -> m (MName, FilePath, Source, [S.Ann S.Import])
 loadModuleHeader searchPaths target = do

--- a/src/Facet/Driver.hs
+++ b/src/Facet/Driver.hs
@@ -25,7 +25,7 @@ import           Control.Carrier.Reader
 import           Control.Effect.Error
 import           Control.Effect.Lens (use, uses, (.=))
 import           Control.Effect.State
-import           Control.Lens (Lens, Lens', at, lens)
+import           Control.Lens (Lens, Lens', at, lens, (^.))
 import           Control.Monad.IO.Class
 import           Data.Foldable (toList)
 import           Data.Maybe (catMaybes)
@@ -103,8 +103,9 @@ reloadModules = do
     i <- fresh
     outputDocLn $ annotate Progress (brackets (ratio i nModules)) <+> nest 2 (group (fillSep [ pretty "Loading", prettyMName name ]))
 
+    modules <- use modules_
     -- FIXME: skip gracefully (maybe print a message) if any of its imports are unavailable due to earlier errors
-    loaded <- traverse (>>= snd) <$> traverse (use . (modules_.) . at) imports
+    let loaded = traverse (\ name -> modules^.at name >>= snd) imports
     for loaded $ \ loaded ->
       (Just <$> loadModule h{ imports = loaded }) `catchError` \ err -> Nothing <$ outputDocLn (prettyNotice err)
   let nSuccess = length (catMaybes results)

--- a/src/Facet/Graph.hs
+++ b/src/Facet/Graph.hs
@@ -50,14 +50,14 @@ restrict (Graph g) s = Graph $ Map.restrictKeys g s
 insert :: Maybe FilePath -> Module -> Graph -> Graph
 insert p m@Module{ name } = Graph . Map.insert name (p, Just m) . getGraph
 
-lookupM :: Alternative m => MName -> Graph -> m (Maybe FilePath, Module)
-lookupM n = maybe empty pure . (sequenceA <=< Map.lookup n . getGraph)
+lookupM :: Alternative m => MName -> Graph -> m (Maybe FilePath, Maybe Module)
+lookupM n = maybe empty pure . Map.lookup n . getGraph
 
 lookupWith :: (Alternative m, Monad m) => (Name -> Module -> m res) -> Graph -> Module -> Q Name -> m res
 lookupWith lookup graph mod@Module{ name } (m:.:n)
   =   guard (m == name || m == Nil) *> lookup n mod
   <|> guard (m == Nil) *> asum (maybe empty (lookup n) . snd <$> getGraph graph)
-  <|> guard (m /= Nil) *> (lookupM m graph >>= lookup n . snd)
+  <|> guard (m /= Nil) *> (lookupM m graph >>= maybe empty pure . snd >>= lookup n)
 
 lookupQ :: (Alternative m, Monad m) => Graph -> Module -> Q Name -> m (Q Name :=: Maybe Def ::: Type)
 lookupQ = lookupWith lookupD

--- a/src/Facet/Graph.hs
+++ b/src/Facet/Graph.hs
@@ -62,6 +62,7 @@ lookupWith lookup graph mod@Module{ name } (m:.:n)
 lookupQ :: (Alternative m, Monad m) => Graph -> Module -> Q Name -> m (Q Name :=: Maybe Def ::: Type)
 lookupQ = lookupWith lookupD
 
+
 -- FIXME: enrich this with source references for each
 newtype GraphErr = CyclicImport (Snoc MName)
 

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -115,7 +115,7 @@ loop = do
     Just src -> do
       graph <- use (target_.modules_)
       targets <- use (target_.targets_)
-      let ops = foldMap (\ name -> lookupM name graph >>= map (\ (op, assoc) -> (name, op, assoc)) . operators . snd) (toList targets)
+      let ops = foldMap (\ name -> lookupM name graph >>= maybe [] pure . snd >>= map (\ (op, assoc) -> (name, op, assoc)) . operators) (toList targets)
       action <- rethrowParseErrors @Style (runParserWithSource src (runFacet (map makeOperator ops) commandParser))
       runReader src $ runAction action
     Nothing  -> pure ()

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -24,7 +24,7 @@ runFile searchPaths path = runStack $ do
   -- FIXME: look up and evaluate the main function in the module we were passed?
   ExitSuccess <$ for_ modules (\ (name, path, src, imports) -> loadModule name path src imports)
   where
-  toNode (n, path, source, imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (n, path, source, imports')
+  toNode (ModuleHeader n path source imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (n, path, source, imports')
   runStack
     = runOutput
     . runTime

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -22,11 +22,11 @@ runFile searchPaths path = runStack $ do
   targetHead <- loadModuleHeader searchPaths (Left path)
   modules <- rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) [headerNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
-  ExitSuccess <$ for_ modules (\ h@(ModuleHeader name _ _ imports) -> do
+  ExitSuccess <$ for_ modules (\ h@(ModuleHeader name _ _ _) -> do
     graph <- use modules_
-    let loaded = traverse (\ name -> graph^.at name >>= snd) imports
+    let loaded = traverse (\ name -> graph^.at name >>= snd) h
     for_ loaded (\ loaded -> do
-      (path, m) <- loadModule graph h{ imports = loaded }
+      (path, m) <- loadModule graph loaded
       modules_.at name .= Just (Just path, Just m)
       pure m))
   where

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -20,7 +20,7 @@ runFile searchPaths path = runStack $ do
   targetHead <- loadModuleHeader searchPaths (Left path)
   modules <- rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) [headerNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
-  ExitSuccess <$ for_ modules (\ (ModuleHeader name path src imports) -> loadModule name path src imports)
+  ExitSuccess <$ for_ modules loadModule
   where
   runStack
     = runOutput

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -15,6 +15,7 @@ import           Facet.Carrier.Write.General
 import           Facet.Driver
 import           Facet.Graph
 import           Facet.Print (quietOptions)
+import           Facet.Source as Source
 import           Facet.Style
 import           System.Exit
 
@@ -23,10 +24,10 @@ runFile searchPaths path = runStack $ do
   targetHead <- loadModuleHeader searchPaths (Left path)
   modules <- rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) [headerNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
-  ExitSuccess <$ for_ modules (\ h@(ModuleHeader name path _ _) -> do
+  ExitSuccess <$ for_ modules (\ h@(ModuleHeader name src _) -> do
     graph <- use modules_
     let loaded = traverse (\ name -> graph^.at name >>= snd) h
-    for_ loaded (storeModule name path <=< loadModule graph))
+    for_ loaded (storeModule name (Source.path src) <=< loadModule graph))
   where
   runStack
     = runOutput

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -23,10 +23,10 @@ runFile searchPaths path = runStack $ do
   modules <- rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) [headerNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
   ExitSuccess <$ for_ modules (\ h@(ModuleHeader name _ _ imports) -> do
-    modules <- use modules_
-    let loaded = traverse (\ name -> modules^.at name >>= snd) imports
+    graph <- use modules_
+    let loaded = traverse (\ name -> graph^.at name >>= snd) imports
     for_ loaded (\ loaded -> do
-      (path, m) <- loadModule h{ imports = loaded }
+      (path, m) <- loadModule graph h{ imports = loaded }
       modules_.at name .= Just (Just path, Just m)
       pure m))
   where

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -4,6 +4,8 @@ module Facet.Run
 
 import           Control.Carrier.Error.Church
 import           Control.Carrier.State.Church
+import           Control.Effect.Lens (use)
+import           Control.Lens (at)
 import           Data.Foldable (for_)
 import qualified Data.Set as Set
 import           Facet.Carrier.Output.IO
@@ -20,7 +22,9 @@ runFile searchPaths path = runStack $ do
   targetHead <- loadModuleHeader searchPaths (Left path)
   modules <- rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) [headerNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
-  ExitSuccess <$ for_ modules loadModule
+  ExitSuccess <$ for_ modules (\ h@(ModuleHeader _ _ _ imports) -> do
+    loaded <- traverse (>>= snd) <$> traverse (use . (modules_.) . at) imports
+    traverse (\ loaded -> loadModule h{ imports = loaded }) loaded)
   where
   runStack
     = runOutput

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -22,9 +22,9 @@ runFile searchPaths path = runStack $ do
   targetHead <- loadModuleHeader searchPaths (Left path)
   modules <- rethrowGraphErrors [] $ loadOrder (fmap toNode . loadModuleHeader searchPaths . Right) [toNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
-  ExitSuccess <$ for_ modules (\ (name, path, src, imports) -> loadModule name path src imports)
+  ExitSuccess <$ for_ modules (\ (ModuleHeader name path src imports) -> loadModule name path src imports)
   where
-  toNode (ModuleHeader n path source imports) = let imports' = map (Import.name . S.out) imports in Node n imports' (n, path, source, imports')
+  toNode h@(ModuleHeader n _ _ imports) = let imports' = map (Import.name . S.out) imports in Node n imports' h{ imports = imports' }
   runStack
     = runOutput
     . runTime

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -13,18 +13,15 @@ import           Facet.Driver
 import           Facet.Graph
 import           Facet.Print (quietOptions)
 import           Facet.Style
-import qualified Facet.Surface as Import (Import(..))
-import qualified Facet.Surface as S
 import           System.Exit
 
 runFile :: [FilePath] -> FilePath -> IO ExitCode
 runFile searchPaths path = runStack $ do
   targetHead <- loadModuleHeader searchPaths (Left path)
-  modules <- rethrowGraphErrors [] $ loadOrder (fmap toNode . loadModuleHeader searchPaths . Right) [toNode targetHead]
+  modules <- rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) [headerNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
   ExitSuccess <$ for_ modules (\ (ModuleHeader name path src imports) -> loadModule name path src imports)
   where
-  toNode h@(ModuleHeader n _ _ imports) = let imports' = map (Import.name . S.out) imports in Node n imports' h{ imports = imports' }
   runStack
     = runOutput
     . runTime

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -5,7 +5,7 @@ module Facet.Run
 import           Control.Carrier.Error.Church
 import           Control.Carrier.State.Church
 import           Control.Effect.Lens (use)
-import           Control.Lens (at)
+import           Control.Lens (at, (^.))
 import           Data.Foldable (for_)
 import qualified Data.Set as Set
 import           Facet.Carrier.Output.IO
@@ -23,7 +23,8 @@ runFile searchPaths path = runStack $ do
   modules <- rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) [headerNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
   ExitSuccess <$ for_ modules (\ h@(ModuleHeader _ _ _ imports) -> do
-    loaded <- traverse (>>= snd) <$> traverse (use . (modules_.) . at) imports
+    modules <- use modules_
+    let loaded = traverse (\ name -> modules^.at name >>= snd) imports
     traverse (\ loaded -> loadModule h{ imports = loaded }) loaded)
   where
   runStack

--- a/src/Facet/Run.hs
+++ b/src/Facet/Run.hs
@@ -23,10 +23,10 @@ runFile searchPaths path = runStack $ do
   targetHead <- loadModuleHeader searchPaths (Left path)
   modules <- rethrowGraphErrors [] $ loadOrder (fmap headerNode . loadModuleHeader searchPaths . Right) [headerNode targetHead]
   -- FIXME: look up and evaluate the main function in the module we were passed?
-  ExitSuccess <$ for_ modules (\ h@(ModuleHeader name _ _ _) -> do
+  ExitSuccess <$ for_ modules (\ h@(ModuleHeader name path _ _) -> do
     graph <- use modules_
     let loaded = traverse (\ name -> graph^.at name >>= snd) h
-    for_ loaded (uncurry (storeModule name) <=< loadModule graph))
+    for_ loaded (storeModule name path <=< loadModule graph))
   where
   runStack
     = runOutput


### PR DESCRIPTION
This PR skips modules whose dependencies weren’t loaded.