### PR TITLE
Split kinds out of types

### DIFF
--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -33,7 +33,7 @@ instance LeftModule Quantity Context where
 data Binding = Binding
   { name     :: Name
   , quantity :: Quantity
-  , type'    :: Type
+  , type'    :: Either Kind Type
   }
 
 -- | A precondition for use of this instance is that one only ever '<>'s pairs of 'Binding's assigning the same type to the same variable.
@@ -62,7 +62,7 @@ Context es' ! Index i' = withFrozenCallStack $ go es' i'
     | otherwise    = go es (i - 1)
   go _           _ = error $ "Facet.Context.!: index (" <> show i' <> ") out of bounds (" <> show (length es') <> ")"
 
-lookupIndex :: Alt.Alternative m => Name -> Context -> m (Index, Quantity, Type)
+lookupIndex :: Alt.Alternative m => Name -> Context -> m (Index, Quantity, Either Kind Type)
 lookupIndex n = go (Index 0) . elems
   where
   go _ S.Nil            = Alt.empty

--- a/src/Facet/Core/Module.hs
+++ b/src/Facet/Core/Module.hs
@@ -90,21 +90,21 @@ newtype Import = Import { name :: MName }
 
 data Def
   = DTerm (Maybe Expr) Type
-  | DData Scope Type
-  | DInterface Scope Type
-  | DModule Scope Type
+  | DData Scope Kind
+  | DInterface Scope Kind
+  | DModule Scope Kind
 
 unDTerm :: Alternative m => Def -> m (Maybe Expr ::: Type)
 unDTerm = \case
   DTerm expr _T -> pure $ expr ::: _T
   _             -> empty
 
-unDData :: Alternative m => Def -> m (Scope ::: Type)
+unDData :: Alternative m => Def -> m (Scope ::: Kind)
 unDData = \case
   DData cs _K -> pure $ cs ::: _K
   _           -> empty
 
-unDInterface :: Alternative m => Def -> m (Scope ::: Type)
+unDInterface :: Alternative m => Def -> m (Scope ::: Kind)
 unDInterface = \case
   DInterface cs _K -> pure $ cs ::: _K
   _                -> empty

--- a/src/Facet/Core/Module.hs
+++ b/src/Facet/Core/Module.hs
@@ -21,6 +21,8 @@ module Facet.Core.Module
 
 import           Control.Applicative (Alternative(..))
 import           Control.Lens (Lens', coerced, lens)
+import           Control.Monad ((<=<))
+import           Data.Bifunctor (first)
 import           Data.Foldable (asum)
 import qualified Data.Map as Map
 import           Facet.Core.Term
@@ -51,40 +53,35 @@ scope_ :: Lens' Module Scope
 scope_ = lens scope (\ m scope -> m{ scope })
 
 
-lookupC :: Alternative m => Name -> Module -> m (RName :=: Maybe Def ::: Type)
+lookupC :: Alternative m => Name -> Module -> m (RName :=: Maybe Expr ::: Type)
 lookupC n Module{ name, scope } = maybe empty pure $ asum (matchDef <$> decls scope)
   where
-  matchDef (d ::: _) = do
-    n :=: v ::: _T <- maybe empty pure d >>= unDData >>= lookupScope n
-    pure $ name:.:n :=: v ::: _T
+  matchDef = matchTerm <=< lookupScope n . tm <=< unDData
+  matchTerm (n :=: d) = (name :.: n :=:) <$> unDTerm d
 
 -- | Look up effect operations.
-lookupE :: Alternative m => Name -> Module -> m (RName :=: Maybe Def ::: Type)
+lookupE :: Alternative m => Name -> Module -> m (RName :=: Def)
 lookupE n Module{ name, scope } = maybe empty pure $ asum (matchDef <$> decls scope)
   where
-  matchDef (d ::: _) = do
-    n :=: _ ::: _T <- maybe empty pure d >>= unDInterface >>= lookupScope n
-    pure $ name:.:n :=: Nothing ::: _T
+  matchDef = fmap (first (name:.:)) . lookupScope n . tm <=< unDInterface
 
-lookupD :: Alternative m => Name -> Module -> m (RName :=: Maybe Def ::: Type)
-lookupD n Module{ name, scope } = maybe empty pure $ do
-  d ::: _T <- Map.lookup n (decls scope)
-  pure $ name:.:n :=: d ::: _T
+lookupD :: Alternative m => Name -> Module -> m (RName :=: Def)
+lookupD n Module{ name, scope } = maybe empty (pure . first (name:.:)) (lookupScope n scope)
 
 
-newtype Scope = Scope { decls :: Map.Map Name (Maybe Def ::: Type) }
+newtype Scope = Scope { decls :: Map.Map Name Def }
   deriving (Monoid, Semigroup)
 
-decls_ :: Lens' Scope (Map.Map Name (Maybe Def ::: Type))
+decls_ :: Lens' Scope (Map.Map Name Def)
 decls_ = coerced
 
-scopeFromList :: [Name :=: Maybe Def ::: Type] -> Scope
-scopeFromList = Scope . Map.fromList . map (\ (n :=: v ::: _T) -> (n, v ::: _T))
+scopeFromList :: [Name :=: Def] -> Scope
+scopeFromList = Scope . Map.fromList . map (\ (n :=: v) -> (n, v))
 
-scopeToList :: Scope -> [Name :=: Maybe Def ::: Type]
-scopeToList = map (\ (n, v ::: _T) -> n :=: v ::: _T) . Map.toList . decls
+scopeToList :: Scope -> [Name :=: Def]
+scopeToList = map (uncurry (:=:)) . Map.toList . decls
 
-lookupScope :: Alternative m => Name -> Scope -> m (Name :=: Maybe Def ::: Type)
+lookupScope :: Alternative m => Name -> Scope -> m (Name :=: Def)
 lookupScope n (Scope ds) = maybe empty (pure . (n :=:)) (Map.lookup n ds)
 
 
@@ -92,22 +89,22 @@ newtype Import = Import { name :: MName }
 
 
 data Def
-  = DTerm Expr
-  | DData Scope
-  | DInterface Scope
-  | DModule Scope
+  = DTerm (Maybe Expr) Type
+  | DData Scope Type
+  | DInterface Scope Type
+  | DModule Scope Type
 
-unDTerm :: Alternative m => Def -> m Expr
+unDTerm :: Alternative m => Def -> m (Maybe Expr ::: Type)
 unDTerm = \case
-  DTerm expr -> pure expr
-  _          -> empty
-
-unDData :: Alternative m => Def -> m Scope
-unDData = \case
-  DData cs -> pure cs
-  _        -> empty
-
-unDInterface :: Alternative m => Def -> m Scope
-unDInterface = \case
-  DInterface cs -> pure cs
+  DTerm expr _T -> pure $ expr ::: _T
   _             -> empty
+
+unDData :: Alternative m => Def -> m (Scope ::: Type)
+unDData = \case
+  DData cs _K -> pure $ cs ::: _K
+  _           -> empty
+
+unDInterface :: Alternative m => Def -> m (Scope ::: Type)
+unDInterface = \case
+  DInterface cs _K -> pure $ cs ::: _K
+  _                -> empty

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -45,6 +45,7 @@ data Kind
   = KType
   | KInterface
   | KArrow (Maybe Name) Kind Kind
+  deriving (Eq, Ord, Show)
 
 
 -- Types

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -44,7 +44,7 @@ import           Prelude hiding (lookup)
 data Kind
   = KType
   | KInterface
-  | KArrow Kind Kind
+  | KArrow (Maybe Name) Kind Kind
 
 
 -- Types

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -42,8 +42,8 @@ import           Prelude hiding (lookup)
 -- Kinds
 
 data Kind
-  = Type
-  | Interface
+  = KType
+  | KInterface
 
 -- Types
 

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -51,9 +51,7 @@ data Kind
 -- Types
 
 data Type
-  = VType
-  | VInterface
-  | VString
+  = VString
   | VForAll Name Kind (Type -> Type)
   | VArrow (Maybe Name) Quantity Type Type
   | VNe (Var (Either Meta Level)) (Snoc Type) (Snoc Type)
@@ -84,8 +82,6 @@ occursIn :: (Var (Either Meta Level) -> Bool) -> Level -> Type -> Bool
 occursIn p = go
   where
   go d = \case
-    VType          -> False
-    VInterface     -> False
     VForAll _ _ b  -> go (succ d) (b (free d))
     VArrow _ _ a b -> go d a || go d b
     VComp s t      -> any (go d) s || go d t
@@ -118,9 +114,7 @@ infixl 9 $$$, $$$*
 -- Type expressions
 
 data TExpr
-  = TType
-  | TInterface
-  | TString
+  = TString
   | TVar (Var (Either Meta Index))
   | TForAll Name Kind TExpr
   | TArrow (Maybe Name) Quantity TExpr TExpr
@@ -134,8 +128,6 @@ data TExpr
 
 quote :: Level -> Type -> TExpr
 quote d = \case
-  VType          -> TType
-  VInterface     -> TInterface
   VString        -> TString
   VForAll n t b  -> TForAll n t (quote (succ d) (b (free d)))
   VArrow n q a b -> TArrow n q (quote d a) (quote d b)
@@ -145,8 +137,6 @@ quote d = \case
 eval :: HasCallStack => Subst -> Snoc (Either Type a) -> TExpr -> Type
 eval subst = go where
   go env = \case
-    TType                 -> VType
-    TInterface            -> VInterface
     TString               -> VString
     TVar (Global n)       -> global n
     TVar (Free (Right v)) -> fromLeft (error ("term variable at index " <> show v)) (env ! getIndex v)

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -54,7 +54,7 @@ data Type
   = VType
   | VInterface
   | VString
-  | VForAll Name Type (Type -> Type)
+  | VForAll Name Kind (Type -> Type)
   | VArrow (Maybe Name) Quantity Type Type
   | VNe (Var (Either Meta Level)) (Snoc Type) (Snoc Type)
   | VComp [Type] Type
@@ -86,7 +86,7 @@ occursIn p = go
   go d = \case
     VType          -> False
     VInterface     -> False
-    VForAll _ t b  -> go d t || go (succ d) (b (free d))
+    VForAll _ _ b  -> go (succ d) (b (free d))
     VArrow _ _ a b -> go d a || go d b
     VComp s t      -> any (go d) s || go d t
     VNe h ts sp    -> p h || any (go d) ts || any (go d) sp
@@ -122,7 +122,7 @@ data TExpr
   | TInterface
   | TString
   | TVar (Var (Either Meta Index))
-  | TForAll Name TExpr TExpr
+  | TForAll Name Kind TExpr
   | TArrow (Maybe Name) Quantity TExpr TExpr
   | TComp [TExpr] TExpr
   | TInst TExpr TExpr
@@ -137,7 +137,7 @@ quote d = \case
   VType          -> TType
   VInterface     -> TInterface
   VString        -> TString
-  VForAll n t b  -> TForAll n (quote d t) (quote (succ d) (b (free d)))
+  VForAll n t b  -> TForAll n t (quote (succ d) (b (free d)))
   VArrow n q a b -> TArrow n q (quote d a) (quote d b)
   VComp s t      -> TComp (quote d <$> s) (quote d t)
   VNe n ts sp    -> foldl' (&) (foldl' (&) (TVar (fmap (levelToIndex d) <$> n)) (flip TInst . quote d <$> ts)) (flip TApp . quote d <$> sp)
@@ -151,7 +151,7 @@ eval subst = go where
     TVar (Global n)       -> global n
     TVar (Free (Right v)) -> fromLeft (error ("term variable at index " <> show v)) (env ! getIndex v)
     TVar (Free (Left m))  -> maybe (metavar m) tm (lookupMeta m subst)
-    TForAll n t b         -> VForAll n (go env t) (\ v -> go (env :> Left v) b)
+    TForAll n t b         -> VForAll n t (\ v -> go (env :> Left v) b)
     TArrow n q a b        -> VArrow n q (go env a) (go env b)
     TComp s t             -> VComp (go env <$> s) (go env t)
     TInst f a             -> go env f $$$ go env a
@@ -160,13 +160,13 @@ eval subst = go where
 
 -- Substitution
 
-newtype Subst = Subst (IntMap.IntMap (Maybe Type ::: Type))
+newtype Subst = Subst (IntMap.IntMap (Maybe Type ::: Kind))
   deriving (Monoid, Semigroup)
 
-insert :: Meta -> Maybe Type ::: Type -> Subst -> Subst
+insert :: Meta -> Maybe Type ::: Kind -> Subst -> Subst
 insert (Meta i) t (Subst metas) = Subst (IntMap.insert i t metas)
 
-lookupMeta :: Meta -> Subst -> Maybe (Type ::: Type)
+lookupMeta :: Meta -> Subst -> Maybe (Type ::: Kind)
 lookupMeta (Meta i) (Subst metas) = do
   v ::: _T <- IntMap.lookup i metas
   (::: _T) <$> v
@@ -174,9 +174,9 @@ lookupMeta (Meta i) (Subst metas) = do
 solveMeta :: Meta -> Type -> Subst -> Subst
 solveMeta (Meta i) t (Subst metas) = Subst (IntMap.update (\ (_ ::: _T) -> Just (Just t ::: _T)) i metas)
 
-declareMeta :: Type -> Subst -> (Subst, Meta)
+declareMeta :: Kind -> Subst -> (Subst, Meta)
 declareMeta _K (Subst metas) = (Subst (IntMap.insert v (Nothing ::: _K) metas), Meta v) where
   v = maybe 0 (succ . fst . fst) (IntMap.maxViewWithKey metas)
 
-metas :: Subst -> [Meta :=: Maybe Type ::: Type]
+metas :: Subst -> [Meta :=: Maybe Type ::: Kind]
 metas (Subst metas) = map (\ (k, v) -> Meta k :=: v) (IntMap.toList metas)

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -44,6 +44,7 @@ import           Prelude hiding (lookup)
 data Kind
   = KType
   | KInterface
+  | KArrow Kind Kind
 
 
 -- Types

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -1,6 +1,8 @@
 module Facet.Core.Type
-( -- * Types
-  Type(..)
+( -- * Kinds
+  Kind(..)
+  -- * Types
+, Type(..)
 , global
 , free
 , metavar
@@ -36,6 +38,12 @@ import           Facet.Syntax
 import           Facet.Usage
 import           GHC.Stack
 import           Prelude hiding (lookup)
+
+-- Kinds
+
+data Kind
+  = Type
+  | Interface
 
 -- Types
 

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -45,6 +45,7 @@ data Kind
   = KType
   | KInterface
 
+
 -- Types
 
 data Type

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -252,11 +252,11 @@ warn reason = do
 
 -- Patterns
 
-assertMatch :: (HasCallStack, Has (Throw Err) sig m) => (Type -> Maybe out) -> String -> Type -> Elab m out
-assertMatch pat exp _T = maybe (mismatch (Left exp) (Right _T)) pure (pat _T)
+assertMatch :: (HasCallStack, Has (Throw Err) sig m) => (Either Kind Type -> Maybe out) -> String -> Either Kind Type -> Elab m out
+assertMatch pat exp _T = maybe (mismatch (Left exp) _T) pure (pat _T)
 
 assertFunction :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m (Maybe Name ::: (Quantity, Type), Type)
-assertFunction = assertMatch (\case{ VArrow n q t b -> pure (n ::: (q, t), b) ; _ -> Nothing }) "_ -> _"
+assertFunction = assertMatch (\case{ Right (VArrow n q t b) -> pure (n ::: (q, t), b) ; _ -> Nothing }) "_ -> _" . Right
 
 
 -- Unification

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -17,6 +17,7 @@ module Facet.Elab
 , Err(..)
 , ErrReason(..)
 , err
+, couldNotUnify
 , couldNotSynthesize
 , resourceMismatch
 , freeVariable

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -99,9 +99,9 @@ instantiate inst = go
 
 resolveWith
   :: (HasCallStack, Has (Throw Err) sig m)
-  => (forall m . Alternative m => Name -> Module -> m (RName :=: Maybe Def ::: Type))
+  => (forall m . Alternative m => Name -> Module -> m (RName :=: d ::: t))
   -> QName
-  -> Elab m (RName :=: Maybe Def ::: Type)
+  -> Elab m (RName :=: d ::: t)
 resolveWith lookup n = asks (\ StaticContext{ module', graph } -> lookupWith lookup graph module' n) >>= \case
   []  -> freeVariable n
   [v] -> pure v

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -298,7 +298,6 @@ unify t1 t2 = type' t1 t2
     (t1, VNe (Free (Left v2)) Nil Nil)                           -> solve v2 t1
     (VForAll n t1 b1, VForAll _ t2 b2)                           -> kind t1 t2 >> depth >>= \ d -> Binding n zero (Left t1) |- type' (b1 (T.free d)) (b2 (T.free d))
     (VForAll{}, _)                                               -> nope
-    -- FIXME: this must unify the signatures
     (VArrow _ _ a1 b1, VArrow _ _ a2 b2)                         -> type' a1 a2 >> type' b1 b2
     (VArrow{}, _)                                                -> nope
     (VComp s1 t1, VComp s2 t2)                                   -> sig s1 s2 >> type' t1 t2

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -296,10 +296,6 @@ unify t1 t2 = type' t1 t2
     (VNe (Free (Left v1)) Nil Nil, VNe (Free (Left v2)) Nil Nil) -> flexFlex v1 v2
     (VNe (Free (Left v1)) Nil Nil, t2)                           -> solve v1 t2
     (t1, VNe (Free (Left v2)) Nil Nil)                           -> solve v2 t1
-    (VType, VType)                                               -> pure ()
-    (VType, _)                                                   -> nope
-    (VInterface, VInterface)                                     -> pure ()
-    (VInterface, _)                                              -> nope
     (VForAll n t1 b1, VForAll _ t2 b2)                           -> kind t1 t2 >> depth >>= \ d -> Binding n zero (Left t1) |- type' (b1 (T.free d)) (b2 (T.free d))
     (VForAll{}, _)                                               -> nope
     -- FIXME: this must unify the signatures

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -184,7 +184,7 @@ data ErrReason
   = FreeVariable QName
   -- FIXME: add source references for the imports, definition sites, and any re-exports.
   | AmbiguousName QName [RName]
-  | CouldNotSynthesize String
+  | CouldNotSynthesize
   | ResourceMismatch Name Quantity Quantity
   | Mismatch (Either String (Either Kind Type)) (Either Kind Type)
   | Hole Name Type
@@ -219,8 +219,8 @@ mismatch exp act = withFrozenCallStack $ err $ Mismatch exp act
 couldNotUnify :: (HasCallStack, Has (Throw Err) sig m) => Either Kind Type -> Either Kind Type -> Elab m a
 couldNotUnify t1 t2 = withFrozenCallStack $ mismatch (Right t2) t1
 
-couldNotSynthesize :: (HasCallStack, Has (Throw Err) sig m) => String -> Elab m a
-couldNotSynthesize v = withFrozenCallStack $ err $ CouldNotSynthesize v
+couldNotSynthesize :: (HasCallStack, Has (Throw Err) sig m) => Elab m a
+couldNotSynthesize = withFrozenCallStack $ err CouldNotSynthesize
 
 resourceMismatch :: (HasCallStack, Has (Throw Err) sig m) => Name -> Quantity -> Quantity -> Elab m a
 resourceMismatch n exp act = withFrozenCallStack $ err $ ResourceMismatch n exp act

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -113,7 +113,7 @@ resolveC = resolveWith lookupC
 resolveQ :: (HasCallStack, Has (Throw Err) sig m) => QName -> Elab m (RName :=: Maybe Def ::: Type)
 resolveQ = resolveWith lookupD
 
-lookupInContext :: Alternative m => QName -> Context -> m (Index, Quantity, Type)
+lookupInContext :: Alternative m => QName -> Context -> m (Index, Quantity, Either Kind Type)
 lookupInContext (m:.n)
   | m == Nil  = lookupIndex n
   | otherwise = const Alt.empty
@@ -299,7 +299,7 @@ unify t1 t2 = type' t1 t2
     (VType, _)                                                   -> nope
     (VInterface, VInterface)                                     -> pure ()
     (VInterface, _)                                              -> nope
-    (VForAll n t1 b1, VForAll _ t2 b2)                           -> type' t1 t2 >> depth >>= \ d -> Binding n zero t1 |- type' (b1 (T.free d)) (b2 (T.free d))
+    (VForAll n t1 b1, VForAll _ t2 b2)                           -> type' t1 t2 >> depth >>= \ d -> Binding n zero (Right t1) |- type' (b1 (T.free d)) (b2 (T.free d))
     (VForAll{}, _)                                               -> nope
     -- FIXME: this must unify the signatures
     (VArrow _ _ a1 b1, VArrow _ _ a2 b2)                         -> type' a1 a2 >> type' b1 b2

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -38,6 +38,7 @@ module Facet.Elab
 , use
 , extendSig
 , elabWith
+, elabKind
 , elabType
 , elabTerm
 , elabSynthTerm
@@ -352,6 +353,9 @@ elabWith scale k m = runState k mempty . runWriter (const pure) $ do
   let stat = StaticContext{ graph, module', source, scale }
       ctx  = ElabContext{ context = Context.empty, sig = [], spans = Nil }
   runReader stat . runReader ctx . runElab $ m
+
+elabKind :: Has (Reader Graph :+: Reader Module :+: Reader Source) sig m => Elab m Kind -> m Kind
+elabKind = elabWith zero (const pure)
 
 elabType :: (HasCallStack, Has (Reader Graph :+: Reader Module :+: Reader Source) sig m) => Elab m TExpr -> m Type
 elabType = elabWith zero (\ subst t -> pure (T.eval subst Nil t))

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -95,7 +95,7 @@ global (q ::: _T) = Synth $ instantiate XInst (XVar (Global q) ::: _T)
 -- FIXME: effect ops in the sig are available whether or not they’re in scope
 var :: (HasCallStack, Has (Throw Err) sig m) => QName -> Synth m Expr
 var n = Synth $ ask >>= \ StaticContext{ module', graph } -> ask >>= \ ElabContext{ context, sig } -> if
-  | Just (i, q, _T) <- lookupInContext n context       -> use i q $> (XVar (Free i) ::: _T)
+  | Just (i, q, Right _T) <- lookupInContext n context       -> use i q $> (XVar (Free i) ::: _T)
   | Just (_ :=: Just (DTerm x) ::: _T) <- lookupInSig n module' graph sig -> instantiate XInst (x ::: _T)
   | otherwise                                          -> do
     n :=: _ ::: _T <- resolveQ n
@@ -110,7 +110,7 @@ tlam :: (HasCallStack, Has (Throw Err) sig m) => Check m Expr -> Check m Expr
 tlam b = Check $ \ _T -> do
   (n ::: _A, _B) <- assertQuantifier _T
   d <- depth
-  b' <- Binding n zero _A |- check (b ::: _B (T.free d))
+  b' <- Binding n zero (Right _A) |- check (b ::: _B (T.free d))
   pure $ XTLam b'
 
 lam :: (HasCallStack, Has (Throw Err) sig m) => [(Bind m (Pattern Name), Check m Expr)] -> Check m Expr
@@ -137,7 +137,7 @@ wildcardP :: Bind m (ValuePattern Name)
 wildcardP = Bind $ \ _ _ -> fmap (PWildcard,)
 
 varP :: (HasCallStack, Has (Throw Err) sig m) => Name -> Bind m (ValuePattern Name)
-varP n = Bind $ \ q _A b -> Check $ \ _B -> (PVar n,) <$> (Binding n q (wrap _A) |- check (b ::: _B))
+varP n = Bind $ \ q _A b -> Check $ \ _B -> (PVar n,) <$> (Binding n q (Right (wrap _A)) |- check (b ::: _B))
   where
   wrap = \case
     VComp sig _A -> VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit")) Nil Nil) (VComp sig _A)
@@ -162,14 +162,14 @@ fieldsP = foldr cons
 allP :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => Name -> Bind m (EffectPattern Name)
 allP n = Bind $ \ q _A b -> Check $ \ _B -> do
   (sig, _T) <- assertComp _A
-  (PAll n,) <$> (Binding n q (VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit")) Nil Nil) (VComp sig _T)) |- check (b ::: _B))
+  (PAll n,) <$> (Binding n q (Right (VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit")) Nil Nil) (VComp sig _T))) |- check (b ::: _B))
 
 effP :: (HasCallStack, Has (Throw Err) sig m) => QName -> [Bind m (ValuePattern Name)] -> Name -> Bind m (Pattern Name)
 effP n ps v = Bind $ \ q _A b -> Check $ \ _B -> do
   StaticContext{ module', graph } <- ask
   (sig, _A') <- assertComp _A
   n' ::: _T <- maybe (freeVariable n) (\ (n :=: _ ::: _T) -> instantiate const (n ::: _T)) (lookupInSig n module' graph sig)
-  (ps', b') <- check (bind (fieldsP (Bind (\ q' _A' b -> ([],) <$> Check (\ _B -> Binding v q' (VArrow Nothing Many _A' _A) |- check (b ::: _B)))) ps ::: (q, _T)) b ::: _B)
+  (ps', b') <- check (bind (fieldsP (Bind (\ q' _A' b -> ([],) <$> Check (\ _B -> Binding v q' (Right (VArrow Nothing Many _A' _A)) |- check (b ::: _B)))) ps ::: (q, _T)) b ::: _B)
   pure (peff n' (fromList ps') v, b')
 
 
@@ -220,7 +220,7 @@ abstractType body = go
   go = \case
     VArrow  (Just n) q a b -> do
       level <- depth
-      b' <- Binding n q a |- go b
+      b' <- Binding n q (Right a) |- go b
       pure $ TForAll n (T.quote level a) b'
     _                       -> body
 

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -333,15 +333,15 @@ elabModule (S.Ann _ _ (S.Module mname is os ds)) = execState (Module mname [] os
 -- Errors
 
 assertQuantifier :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m (Name ::: Type, Type -> Type)
-assertQuantifier = assertMatch (\case{ VForAll n t b -> pure (n ::: t, b) ; _ -> Nothing }) "{_} -> _"
+assertQuantifier = assertMatch (\case{ Right (VForAll n t b) -> pure (n ::: t, b) ; _ -> Nothing }) "{_} -> _" . Right
 
 -- | Expect a tacit (non-variable-binding) function type.
 assertTacitFunction :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m ((Quantity, Type), Type)
-assertTacitFunction = assertMatch (\case{ VArrow Nothing q t b -> pure ((q, t), b) ; _ -> Nothing }) "_ -> _"
+assertTacitFunction = assertMatch (\case{ Right (VArrow Nothing q t b) -> pure ((q, t), b) ; _ -> Nothing }) "_ -> _" . Right
 
 -- | Expect a computation type with effects.
 assertComp :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m ([Type], Type)
-assertComp = assertMatch (\case{ VComp s t -> pure (s, t) ; _ -> Nothing }) "[_] _"
+assertComp = assertMatch (\case{ Right (VComp s t) -> pure (s, t) ; _ -> Nothing }) "[_] _" . Right
 
 
 -- Elaboration

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -184,7 +184,7 @@ synthExpr (S.Ann s _ e) = mapSynth (pushSpan s) $ case e of
   S.Hole{}   -> nope
   S.Lam{}    -> nope
   where
-  nope = Synth $ couldNotSynthesize (show e)
+  nope = Synth couldNotSynthesize
 
 checkExpr :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => S.Ann S.Expr -> Check m Expr
 checkExpr expr@(S.Ann s _ e) = mapCheck (pushSpan s) $ case e of

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -306,20 +306,20 @@ elabModule (S.Ann _ _ (S.Module mname is os ds)) = execState (Module mname [] os
     -- FIXME: check for redundant naming
 
     -- elaborate all the types first
-    es <- for ds $ \ (S.Ann _ _ (dname, S.Ann _ _ (S.Decl tele def))) -> case def of
-      S.DataDef cs -> Nothing <$ do
+    es <- for ds $ \ (S.Ann _ _ (dname, S.Ann _ _ def)) -> case def of
+      S.DataDef cs tele -> Nothing <$ do
         _K <- runModule $ elabKind $ checkIsType (synthKind tele ::: KType)
         scope_.decls_.at dname .= Just (DData mempty _K)
         decls <- runModule $ elabDataDef (dname ::: _K) cs
         for_ decls $ \ (dname :=: decl) -> scope_.decls_.at dname .= Just decl
 
-      S.InterfaceDef os -> Nothing <$ do
+      S.InterfaceDef os tele -> Nothing <$ do
         _K <- runModule $ elabKind $ checkIsType (synthKind tele ::: KType)
         scope_.decls_.at dname .= Just (DInterface mempty _K)
         decls <- runModule $ elabInterfaceDef (dname ::: _K) os
         for_ decls $ \ (dname :=: decl) -> scope_.decls_.at dname .= Just decl
 
-      S.TermDef t -> do
+      S.TermDef t tele -> do
         _T <- runModule $ elabType $ checkIsType (synthType tele ::: KType)
         scope_.decls_.at dname .= Just (DTerm Nothing _T)
         pure (Just (dname, t ::: _T))

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -23,6 +23,7 @@ import           Data.Bifunctor (first)
 import           Data.Foldable (foldl')
 import           Data.Functor (($>))
 import           Facet.Context
+import           Facet.Core.Module
 import           Facet.Core.Type
 import           Facet.Elab
 import           Facet.Name
@@ -35,9 +36,10 @@ import           GHC.Stack
 tvar :: (HasCallStack, Has (Throw Err) sig m) => QName -> IsType m TExpr
 tvar n = IsType $ views context_ (lookupInContext n) >>= \case
   Just (i, q, Right _T) -> use i q $> (TVar (Free (Right i)) ::: _T)
-  _                     -> do
-    q :=: _ ::: _T <- resolveQ n
-    pure $ TVar (Global q) ::: _T
+  _                     -> resolveQ n >>= \case
+    q :=: DData      _ _K -> pure $ TVar (Global q) ::: _K
+    q :=: DInterface _ _K -> pure $ TVar (Global q) ::: _K
+    _                     -> freeVariable n
 
 
 _Type :: IsType m TExpr

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -34,8 +34,8 @@ import           GHC.Stack
 
 tvar :: (HasCallStack, Has (Throw Err) sig m) => QName -> IsType m TExpr
 tvar n = IsType $ views context_ (lookupInContext n) >>= \case
-  Just (i, q, _T) -> use i q $> (TVar (Free (Right i)) ::: _T)
-  Nothing         -> do
+  Just (i, q, Right _T) -> use i q $> (TVar (Free (Right i)) ::: _T)
+  _                     -> do
     q :=: _ ::: _T <- resolveQ n
     instantiate TInst $ TVar (Global q) ::: _T
 
@@ -56,7 +56,7 @@ forAll (n ::: t) b = IsType $ do
   env <- views context_ toEnv
   subst <- get
   let vt = eval subst (Left <$> env) t'
-  b' <- Binding n zero vt |- checkIsType (b ::: VType)
+  b' <- Binding n zero (Right vt) |- checkIsType (b ::: VType)
   pure $ TForAll n t' b' ::: VType
 
 (-->) :: (HasCallStack, Has (Throw Err) sig m) => Maybe Name ::: IsType m (Quantity, TExpr) -> IsType m TExpr -> IsType m TExpr

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -37,7 +37,7 @@ tvar n = IsType $ views context_ (lookupInContext n) >>= \case
   Just (i, q, Right _T) -> use i q $> (TVar (Free (Right i)) ::: _T)
   _                     -> do
     q :=: _ ::: _T <- resolveQ n
-    instantiate TInst $ TVar (Global q) ::: _T
+    pure $ TVar (Global q) ::: _T
 
 
 _Type :: IsType m TExpr

--- a/src/Facet/Eval.hs
+++ b/src/Facet/Eval.hs
@@ -52,8 +52,8 @@ global n = do
   mod <- lift ask
   graph <- lift ask
   case lookupQ graph mod (toQ n) of
-    Just (_ :=: Just (DTerm v) ::: _) -> pure v -- FIXME: store values in the module graph
-    _                                 -> error "throw a real error here"
+    Just (_ :=: DTerm (Just v) _) -> pure v -- FIXME: store values in the module graph
+    _                             -> error "throw a real error here"
 
 var :: (HasCallStack, Applicative m) => Snoc (Value m) -> Index -> m (Value m)
 var env v = pure (env ! getIndex v)

--- a/src/Facet/Graph.hs
+++ b/src/Facet/Graph.hs
@@ -26,7 +26,6 @@ import qualified Data.Map as Map
 import           Data.Monoid (Endo(..))
 import qualified Data.Set as Set
 import           Facet.Core.Module
-import           Facet.Core.Type hiding (insert)
 import           Facet.Name
 import           Facet.Snoc
 import           Facet.Snoc.NonEmpty (fromSnoc, toSnoc)
@@ -60,7 +59,7 @@ lookupWith lookup graph mod@Module{ name } (m:.n)
   <|> guard (m == Nil) *> asum (maybe empty (lookup n) . snd <$> getGraph graph)
   <|> guard (m /= Nil) *> (lookupM (fromSnoc m) graph >>= maybe empty pure . snd >>= lookup n)
 
-lookupQ :: (Alternative m, Monad m) => Graph -> Module -> QName -> m (RName :=: Maybe Def ::: Type)
+lookupQ :: (Alternative m, Monad m) => Graph -> Module -> QName -> m (RName :=: Def)
 lookupQ = lookupWith lookupD
 
 

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -63,8 +63,8 @@ printErrReason opts ctx = group . \case
     <> hardline <> pretty "expected:" <> print exp'
     <> hardline <> pretty "  actual:" <> print act'
     where
-    exp' = either reflow (getPrint . printType opts ctx) exp
-    act' = getPrint (printType opts ctx act)
+    exp' = either reflow (getPrint . either printKind (printType opts ctx)) exp
+    act' = getPrint (either printKind (printType opts ctx) act)
     -- line things up nicely for e.g. wrapped function types
     print = nest 2 . (flatAlt (line <> stimes (3 :: Int) space) mempty <>)
   Hole n _T              ->

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -39,7 +39,7 @@ rethrowElabErrors opts = L.runThrow rethrow
     let n' = intro n d
     in  ( succ d
         , print :> n'
-        , ctx  :> getPrint (ann (n' ::: mult m (printType opts print _T))) )
+        , ctx  :> getPrint (ann (n' ::: mult m (either (printKind print) (printType opts print) _T))) )
   mult m = if
     | m == zero -> (pretty "0" <+>)
     | m == one  -> (pretty "1" <+>)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -50,7 +50,7 @@ printErrReason :: Options -> Snoc Print -> ErrReason -> Doc Style
 printErrReason opts ctx = group . \case
   FreeVariable n         -> fillSep [reflow "variable not in scope:", pretty n]
   AmbiguousName n qs     -> fillSep [reflow "ambiguous name", pretty n] <\> nest 2 (reflow "alternatives:" <\> unlines (map pretty qs))
-  CouldNotSynthesize msg -> reflow "could not synthesize a type for" <> softline <> reflow msg
+  CouldNotSynthesize     -> reflow "could not synthesize a type; try a type annotation"
   ResourceMismatch n e a -> fillSep [reflow "uses of variable", pretty n, reflow "didn’t match requirements"]
     <> hardline <> pretty "expected:" <+> prettyQ e
     <> hardline <> pretty "  actual:" <+> prettyQ a

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -34,7 +34,7 @@ rethrowElabErrors opts = L.runThrow rethrow
     ]
     where
     (_, printCtx, ctx) = foldl' combine (0, Nil, Nil) (elems context)
-    subst' = map (\ (m :=: v ::: _T) -> getPrint (ann (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v ::: printType opts printCtx _T))) (metas subst)
+    subst' = map (\ (m :=: v ::: _T) -> getPrint (ann (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v ::: printKind printCtx _T))) (metas subst)
   combine (d, print, ctx) (Binding n m _T) =
     let n' = intro n d
     in  ( succ d

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -63,8 +63,8 @@ printErrReason opts ctx = group . \case
     <> hardline <> pretty "expected:" <> print exp'
     <> hardline <> pretty "  actual:" <> print act'
     where
-    exp' = either reflow (getPrint . either printKind (printType opts ctx)) exp
-    act' = getPrint (either printKind (printType opts ctx) act)
+    exp' = either reflow (getPrint . either (printKind ctx) (printType opts ctx)) exp
+    act' = getPrint (either (printKind ctx) (printType opts ctx) act)
     -- line things up nicely for e.g. wrapped function types
     print = nest 2 . (flatAlt (line <> stimes (3 :: Int) space) mempty <>)
   Hole n _T              ->

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -161,8 +161,6 @@ printTExpr Options{ rname, instantiation } = go
     C.TVar (Global n)       -> qvar n
     C.TVar (Free (Right d)) -> fromMaybe (pretty (getIndex d)) $ env !? getIndex d
     C.TVar (Free (Left m))  -> meta m
-    C.TType                 -> annotate Type $ pretty "Type"
-    C.TInterface            -> annotate Type $ pretty "Interface"
     C.TForAll      n    t b -> braces (ann (intro n d ::: printKind env t)) --> go (env :> intro n d) b
     C.TArrow Nothing  q a b -> mult q (go env a) --> go env b
     C.TArrow (Just n) q a b -> parens (ann (intro n d ::: mult q (go env a))) --> go env b

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -163,7 +163,7 @@ printTExpr Options{ rname, instantiation } = go
     C.TVar (Free (Left m))  -> meta m
     C.TType                 -> annotate Type $ pretty "Type"
     C.TInterface            -> annotate Type $ pretty "Interface"
-    C.TForAll      n    t b -> braces (ann (intro n d ::: go env t)) --> go (env :> intro n d) b
+    C.TForAll      n    t b -> braces (ann (intro n d ::: printKind env t)) --> go (env :> intro n d) b
     C.TArrow Nothing  q a b -> mult q (go env a) --> go env b
     C.TArrow (Just n) q a b -> parens (ann (intro n d ::: mult q (go env a))) --> go env b
     C.TComp [] t            -> go env t

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -142,11 +142,14 @@ suppressInstantiation = const
 
 -- Core printers
 
-printKind :: C.Kind -> Print
-printKind = \case
-  C.KType      -> annotate Type $ pretty "Type"
-  C.KInterface -> annotate Type $ pretty "Interface"
-  C.KArrow a b -> printKind a --> printKind b
+printKind :: Snoc Print -> C.Kind -> Print
+printKind env = \case
+  C.KType               -> annotate Type $ pretty "Type"
+  C.KInterface          -> annotate Type $ pretty "Interface"
+  C.KArrow Nothing  a b -> printKind env a --> printKind env b
+  C.KArrow (Just n) a b -> parens (ann (intro n d ::: printKind env a)) --> printKind env b
+  where
+  d = Name.Level (length env)
 
 printType :: Options -> Snoc Print -> C.Type -> Print
 printType opts env = printTExpr opts env . CT.quote (Name.Level (length env))

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -28,7 +28,6 @@ module Facet.Print
 ) where
 
 import           Data.Foldable (foldl', toList)
-import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import           Data.Traversable (mapAccumL)
@@ -212,21 +211,18 @@ printModule (C.Module mname is _ ds) = module_
   mname
   (qvar (fromList [T.pack "Kernel"]:.U (T.pack "Module")))
   (map (\ (C.Import n) -> import' n) is)
-  (map def (Map.toList (C.decls ds)))
+  (map def (C.scopeToList ds))
   where
-  def (n, Nothing ::: t) = ann
+  def (n :=: d) = ann
     $   qvar (Nil:.n)
-    ::: printType opts Nil t
-  def (n, Just d  ::: t) = ann
-    $   qvar (Nil:.n)
-    ::: defn (printType opts Nil t
-    :=: case d of
-      C.DTerm b  -> printExpr opts Nil b
-      C.DData cs -> annotate Keyword (pretty "data") <+> declList
-        (map (\ (n :=: _ ::: _T) -> ann (cname n ::: printType opts Nil _T)) (C.scopeToList cs))
-      C.DInterface os -> annotate Keyword (pretty "interface") <+> declList
-        (map (\ (n :=: _ ::: _T) -> ann (cname n ::: printType opts Nil _T)) (C.scopeToList os))
-      C.DModule ds -> block (concatWith (surround hardline) (map ((hardline <>) . def) (Map.toList (C.decls ds)))))
+    ::: case d of
+      C.DTerm Nothing  _T ->       printType opts Nil _T
+      C.DTerm (Just b) _T -> defn (printType opts Nil _T :=: printExpr opts Nil b)
+      C.DData cs _K -> annotate Keyword (pretty "data") <+> declList
+        (map def (C.scopeToList cs))
+      C.DInterface os _K -> annotate Keyword (pretty "interface") <+> declList
+        (map def (C.scopeToList os))
+      C.DModule ds _K -> block (concatWith (surround hardline) (map ((hardline <>) . def) (C.scopeToList ds)))
   declList = block . group . concatWith (surround (hardline <> comma <> space)) . map group
   import' n = pretty "import" <+> braces (setPrec Var (prettyMName n))
   module_ n t is ds = ann (setPrec Var (prettyMName n) ::: t) </> concatWith (surround hardline) (is ++ map (hardline <>) ds)
@@ -242,7 +238,6 @@ meta :: Meta -> Print
 meta (Meta m) = setPrec Var $ annotate (Name m) $ pretty '?' <> upper m
 
 local  n d = name lower n (getLevel d)
-cname    n = setPrec Var (annotate Con (pretty n))
 
 name :: (Int -> Print) -> Name -> Int -> Print
 name f n d = setPrec Var . annotate (Name d) $

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -16,6 +16,7 @@ module Facet.Print
 , printInstantiation
 , suppressInstantiation
   -- * Core printers
+, printKind
 , printType
 , printTExpr
 , printExpr
@@ -140,6 +141,12 @@ suppressInstantiation = const
 
 
 -- Core printers
+
+printKind :: C.Kind -> Print
+printKind = \case
+  C.KType      -> annotate Type $ pretty "Type"
+  C.KInterface -> annotate Type $ pretty "Interface"
+  C.KArrow a b -> printKind a --> printKind b
 
 printType :: Options -> Snoc Print -> C.Type -> Print
 printType opts env = printTExpr opts env . CT.quote (Name.Level (length env))

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -218,7 +218,7 @@ showKind :: S.Ann S.Type -> Action
 showKind _T = Action $ do
   _T ::: _K <- runElab $ Elab.elabSynthType (Elab.isType (Elab.synthType _T))
   opts <- get
-  outputDocLn (getPrint (ann (printType opts Nil _T ::: printType opts Nil _K)))
+  outputDocLn (getPrint (ann (printType opts Nil _T ::: printKind Nil _K)))
 
 
 helpDoc :: Doc Style

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -11,8 +11,7 @@ module Facet.Surface
 , Pattern(..)
 , ValPattern(..)
 , EffPattern(..)
-  -- * Declarations
-, Decl(..)
+  -- * Definitions
 , Def(..)
   -- * Modules
 , Module(..)
@@ -91,14 +90,10 @@ data EffPattern = POp QName [Ann ValPattern] Name
 
 -- Declarations
 
-data Decl = Decl (Ann Type) Def
-  deriving (Eq, Show)
-
-
 data Def
-  = DataDef [Ann (Name ::: Ann Type)]
-  | InterfaceDef [Ann (Name ::: Ann Type)]
-  | TermDef (Ann Expr)
+  = DataDef [Ann (Name ::: Ann Type)] (Ann Type)
+  | InterfaceDef [Ann (Name ::: Ann Type)] (Ann Type)
+  | TermDef (Ann Expr) (Ann Type)
   deriving (Eq, Show)
 
 
@@ -109,7 +104,7 @@ data Module = Module
   , imports   :: [Ann Import]
   -- FIXME: store source references for operators’ definitions, for error reporting
   , operators :: [(Op, Assoc)]
-  , defs      :: [Ann (Name, Ann Decl)]
+  , defs      :: [Ann (Name, Ann Def)]
   }
   deriving (Eq, Show)
 

--- a/src/Facet/Surface.hs
+++ b/src/Facet/Surface.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Facet.Surface
 ( -- * Types
-  Type(..)
+  Kind(..)
+, Type(..)
 , Mul(..)
   -- * Expressions
 , Expr(..)
@@ -36,12 +37,16 @@ import Facet.Syntax
 
 -- Types
 
+data Kind
+  = KType
+  | KInterface
+  | KArrow (Maybe Name) (Ann Kind) (Ann Kind)
+  deriving (Eq, Show)
+
 data Type
   = TVar QName
-  | KType
-  | KInterface
   | TString
-  | TForAll Name (Ann Type) (Ann Type)
+  | TForAll Name (Ann Kind) (Ann Type)
   | TArrow (Maybe Name) (Maybe Mul) (Ann Type) (Ann Type)
   | TComp [Ann Interface] (Ann Type)
   | TApp (Ann Type) (Ann Type)
@@ -91,8 +96,8 @@ data EffPattern = POp QName [Ann ValPattern] Name
 -- Declarations
 
 data Def
-  = DataDef [Ann (Name ::: Ann Type)] (Ann Type)
-  | InterfaceDef [Ann (Name ::: Ann Type)] (Ann Type)
+  = DataDef [Ann (Name ::: Ann Type)] (Ann Kind)
+  | InterfaceDef [Ann (Name ::: Ann Type)] (Ann Kind)
   | TermDef (Ann Expr) (Ann Type)
   deriving (Eq, Show)
 

--- a/test/Facet/Core/Type/Test.hs
+++ b/test/Facet/Core/Type/Test.hs
@@ -15,5 +15,5 @@ tests :: IO Bool
 tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
-  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right 0))) (TComp [] (TVar (Free (Right 1)))))
+  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right 0))) (TComp [] (TVar (Free (Right 0)))))
   quote 0 (eval mempty Nil init) === init

--- a/test/Facet/Core/Type/Test.hs
+++ b/test/Facet/Core/Type/Test.hs
@@ -6,6 +6,7 @@ module Facet.Core.Type.Test
 
 import Facet.Core.Type
 import Facet.Name
+import Facet.Semiring
 import Facet.Snoc
 import Facet.Syntax
 import Hedgehog hiding (Var, eval)
@@ -14,5 +15,5 @@ tests :: IO Bool
 tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
-  let init = TForAll (U "A") TType (TForAll (U "x") (TVar (Free (Right 0))) (TComp [] (TVar (Free (Right 1)))))
+  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right 0))) (TComp [] (TVar (Free (Right 1)))))
   quote 0 (eval mempty Nil init) === init


### PR DESCRIPTION
It was always a bit weird conflating the two, e.g. foralls range over types, not terms, but `{ X : String } -> Y` was syntactically valid.

No longer.