### PR TITLE
Structured contexts

### DIFF
--- a/facet.cabal
+++ b/facet.cabal
@@ -113,6 +113,7 @@ library
     Facet.Source
     Facet.Span
     Facet.Style
+    Facet.Subst
     Facet.Surface
     Facet.Syntax
     Facet.Timing

--- a/facet.cabal
+++ b/facet.cabal
@@ -75,6 +75,7 @@ library
     Facet.CLI
     Facet.Context
     Facet.Core.Module
+    Facet.Core.Pattern
     Facet.Core.Term
     Facet.Core.Type
     Facet.Diff

--- a/facet.cabal
+++ b/facet.cabal
@@ -89,6 +89,7 @@ library
     Facet.Elab
     Facet.Elab.Term
     Facet.Elab.Type
+    Facet.Env
     Facet.Eval
     Facet.Flag
     Facet.Format

--- a/src/Facet/Carrier/Throw/Inject.hs
+++ b/src/Facet/Carrier/Throw/Inject.hs
@@ -12,13 +12,13 @@ import Control.Carrier.Reader
 import Control.Effect.Throw
 import Control.Monad.IO.Class
 
-runThrow :: (f -> e) -> ThrowC e f m a -> m a
+runThrow :: (f -> m e) -> ThrowC e f m a -> m a
 runThrow inject (ThrowC m) = runReader inject m
 
-newtype ThrowC e f m a = ThrowC (ReaderC (f -> e) m a)
+newtype ThrowC e f m a = ThrowC (ReaderC (f -> m e) m a)
   deriving (Applicative, Functor, Monad, MonadFail, MonadIO)
 
 instance Has (Throw e) sig m => Algebra (Throw f :+: sig) (ThrowC e f m) where
   alg hdl sig ctx = ThrowC $ ReaderC $ \ inject -> case sig of
-    L (Throw e) -> throwError (inject e)
+    L (Throw e) -> throwError =<< inject e
     R other     -> alg (runThrow inject . hdl) other ctx

--- a/src/Facet/Carrier/Time/System.hs
+++ b/src/Facet/Carrier/Time/System.hs
@@ -34,8 +34,6 @@ newtype TimeC m a = TimeC { runTimeC :: ReaderC Instant m a }
 
 instance Has (Lift IO) sig m => Algebra (Time Instant :+: sig) (TimeC m) where
   alg hdl sig ctx = case sig of
-    L Now           -> (<$ ctx) . Instant <$> sendIO getSystemTime
-    L Epoch         -> TimeC (asks (<$ ctx))
-    L (EraFrom t m) -> TimeC (local (const t) (runTimeC (hdl (m <$ ctx))))
-    R other         -> TimeC (alg (runTimeC . hdl) (R other) ctx)
+    L Now   -> (<$ ctx) . Instant <$> sendIO getSystemTime
+    R other -> TimeC (alg (runTimeC . hdl) (R other) ctx)
   {-# INLINE alg #-}

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -44,14 +44,14 @@ Context es' ! Index i' = withFrozenCallStack $ go es' i'
     | otherwise    = go es (i - 1)
   go _           _ = error $ "Facet.Context.!: index (" <> show i' <> ") out of bounds (" <> show (length es') <> ")"
 
-lookupIndex :: E.Has E.Empty sig m => Name -> Context -> m (Index, Name, Quantity, Classifier)
+lookupIndex :: E.Has E.Empty sig m => Name -> Context -> m (LName Index, Quantity, Classifier)
 lookupIndex n = go (Index 0) . elems
   where
   go _ S.Nil                                        = E.empty
   go i (cs S.:> (q, p))
-    | Just (n' ::: t) <- find ((== n) . tm) p = pure (i, n', q, t)
+    | Just (n' ::: t) <- find ((== n) . tm) p = pure (LName i n', q, t)
     | otherwise                                     = go (succ i) cs
 
 
 toEnv :: Context -> Env.Env Type
-toEnv c = Env.Env (S.fromList (zipWith (\ (_, p) d -> (\ b -> tm b :=: free d (tm b)) <$> p) (toList (elems c)) [0..pred (level c)]))
+toEnv c = Env.Env (S.fromList (zipWith (\ (_, p) d -> (\ b -> tm b :=: free (LName d (tm b))) <$> p) (toList (elems c)) [0..pred (level c)]))

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -23,7 +23,7 @@ newtype Context = Context { elems :: S.Snoc Binding }
 data Binding = Binding
   { name     :: Name
   , quantity :: Quantity
-  , type'    :: Either Kind Type
+  , type'    :: Classifier
   }
 
 
@@ -46,7 +46,7 @@ Context es' ! Index i' = withFrozenCallStack $ go es' i'
     | otherwise    = go es (i - 1)
   go _           _ = error $ "Facet.Context.!: index (" <> show i' <> ") out of bounds (" <> show (length es') <> ")"
 
-lookupIndex :: E.Has E.Empty sig m => Name -> Context -> m (Index, Quantity, Either Kind Type)
+lookupIndex :: E.Has E.Empty sig m => Name -> Context -> m (Index, Quantity, Classifier)
 lookupIndex n = go (Index 0) . elems
   where
   go _ S.Nil            = E.empty

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -8,7 +8,6 @@ module Facet.Context
 , level
 , (!)
 , lookupIndex
-, toEnv
 ) where
 
 import qualified Control.Effect.Empty as E
@@ -54,8 +53,3 @@ lookupIndex n = go (Index 0) . elems
   go i (cs S.:> Binding n' q t)
     | n == n'           = pure (i, q, t)
     | otherwise         = go (succ i) cs
-
-
--- | Construct an environment suitable for evaluation from a 'Context'.
-toEnv :: Context -> S.Snoc Type
-toEnv = S.fromList . map free . enumFromTo 0 . level

--- a/src/Facet/Context.hs
+++ b/src/Facet/Context.hs
@@ -58,9 +58,4 @@ lookupIndex n = go (Index 0) . elems
 
 -- | Construct an environment suitable for evaluation from a 'Context'.
 toEnv :: Context -> S.Snoc Type
-toEnv c = locals 0 (elems c)
-  where
-  d = level c
-  locals i = \case
-    S.Nil     -> S.Nil
-    bs S.:> _ -> locals (succ i) bs S.:> free (indexToLevel d i)
+toEnv = S.fromList . map free . enumFromTo 0 . level

--- a/src/Facet/Core/Pattern.hs
+++ b/src/Facet/Core/Pattern.hs
@@ -1,0 +1,45 @@
+module Facet.Core.Pattern
+( -- * Patterns
+  ValuePattern(..)
+, EffectPattern(..)
+, Pattern(..)
+, pvar
+, pcon
+, peff
+, fill
+) where
+
+import Data.Traversable (mapAccumL)
+import Facet.Name
+import Facet.Snoc
+
+-- Patterns
+
+data ValuePattern a
+  = PWildcard
+  | PVar a
+  | PCon RName (Snoc (ValuePattern a))
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+data EffectPattern a
+  = PAll a
+  | POp RName (Snoc (ValuePattern a)) a
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+data Pattern a
+  = PEff (EffectPattern a)
+  | PVal (ValuePattern a)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
+
+pvar :: a -> Pattern a
+pvar = PVal . PVar
+
+pcon :: RName -> Snoc (ValuePattern a) -> Pattern a
+pcon n fs = PVal $ PCon n fs
+
+peff :: RName -> Snoc (ValuePattern a) -> a -> Pattern a
+peff o vs k = PEff $ POp o vs k
+
+
+fill :: Traversable t => (b -> (b, c)) -> b -> t a -> (b, t c)
+fill f = mapAccumL (const . f)

--- a/src/Facet/Core/Term.hs
+++ b/src/Facet/Core/Term.hs
@@ -13,7 +13,7 @@ import           Facet.Syntax
 -- Term expressions
 
 data Expr
-  = XVar (Var Index)
+  = XVar (Var (Index, Name))
   | XTLam Expr
   | XInst Expr T.TExpr
   | XLam [(Pattern Name, Expr)]

--- a/src/Facet/Core/Term.hs
+++ b/src/Facet/Core/Term.hs
@@ -1,54 +1,14 @@
 module Facet.Core.Term
-( -- * Patterns
-  ValuePattern(..)
-, EffectPattern(..)
-, Pattern(..)
-, pvar
-, pcon
-, peff
-, fill
-  -- * Term expressions
-, Expr(..)
+( -- * Term expressions
+  Expr(..)
 ) where
 
 import           Data.Text (Text)
-import           Data.Traversable (mapAccumL)
+import           Facet.Core.Pattern
 import qualified Facet.Core.Type as T
 import           Facet.Name
 import           Facet.Snoc
 import           Facet.Syntax
-
--- Patterns
-
-data ValuePattern a
-  = PWildcard
-  | PVar a
-  | PCon RName (Snoc (ValuePattern a))
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-data EffectPattern a
-  = PAll a
-  | POp RName (Snoc (ValuePattern a)) a
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-data Pattern a
-  = PEff (EffectPattern a)
-  | PVal (ValuePattern a)
-  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
-
-pvar :: a -> Pattern a
-pvar = PVal . PVar
-
-pcon :: RName -> Snoc (ValuePattern a) -> Pattern a
-pcon n fs = PVal $ PCon n fs
-
-peff :: RName -> Snoc (ValuePattern a) -> a -> Pattern a
-peff o vs k = PEff $ POp o vs k
-
-
-fill :: Traversable t => (b -> (b, c)) -> b -> t a -> (b, t c)
-fill f = mapAccumL (const . f)
-
 
 -- Term expressions
 

--- a/src/Facet/Core/Term.hs
+++ b/src/Facet/Core/Term.hs
@@ -13,7 +13,7 @@ import           Facet.Syntax
 -- Term expressions
 
 data Expr
-  = XVar (Var (Index, Name))
+  = XVar (Var (LName Index))
   | XTLam Expr
   | XInst Expr T.TExpr
   | XLam [(Pattern Name, Expr)]

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -14,7 +14,7 @@ module Facet.Core.Type
 , metavar
 , unNeutral
 , unComp
-, Subject(..)
+, Classifier(..)
 , subjectType
 , occursIn
   -- ** Elimination
@@ -110,11 +110,11 @@ unComp = \case
   _T           -> empty
 
 
-data Subject
+data Classifier
   = SK Kind
   | ST Type
 
-subjectType :: Subject -> Maybe Type
+subjectType :: Classifier -> Maybe Type
 subjectType = \case
   SK _K -> empty
   ST _T -> pure _T

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -15,7 +15,7 @@ module Facet.Core.Type
 , unNeutral
 , unComp
 , Classifier(..)
-, subjectType
+, classifierType
 , occursIn
   -- ** Elimination
 , ($$)
@@ -114,8 +114,8 @@ data Classifier
   = SK Kind
   | ST Type
 
-subjectType :: Classifier -> Maybe Type
-subjectType = \case
+classifierType :: Classifier -> Maybe Type
+classifierType = \case
   SK _K -> empty
   ST _T -> pure _T
 

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -29,7 +29,6 @@ module Facet.Core.Type
 ) where
 
 import           Control.Effect.Empty
-import           Data.Bifunctor (first)
 import           Data.Foldable (foldl')
 import           Data.Function (on, (&))
 import           Data.Maybe (fromMaybe)
@@ -78,7 +77,7 @@ data Type
   = VString
   | VForAll Name Kind (Type -> Type)
   | VArrow (Maybe Name) Quantity Type Type
-  | VNe (Var (Either Meta (Level, Name))) (Snoc Type)
+  | VNe (Var (Either Meta (LName Level))) (Snoc Type)
   | VComp (Signature Type) Type
 
 instance Eq Type where
@@ -91,18 +90,18 @@ instance Ord Type where
 global :: RName -> Type
 global = var . Global
 
-free :: Level -> Name -> Type
-free = curry (var . Free . Right)
+free :: LName Level -> Type
+free = var . Free . Right
 
 metavar :: Meta -> Type
 metavar = var . Free . Left
 
 
-var :: Var (Either Meta (Level, Name)) -> Type
+var :: Var (Either Meta (LName Level)) -> Type
 var v = VNe v Nil
 
 
-unNeutral :: Has Empty sig m => Type -> m (Var (Either Meta (Level, Name)), Snoc Type)
+unNeutral :: Has Empty sig m => Type -> m (Var (Either Meta (LName Level)), Snoc Type)
 unNeutral = \case
   VNe h sp -> pure (h, sp)
   _        -> empty
@@ -127,7 +126,7 @@ occursIn :: Meta -> Level -> Type -> Bool
 occursIn p = go
   where
   go d = \case
-    VForAll n _ b  -> go (succ d) (b (free d n))
+    VForAll n _ b  -> go (succ d) (b (free (LName d n)))
     VArrow _ _ a b -> go d a || go d b
     VComp s t      -> any (go d) s || go d t
     VNe h sp       -> any (either (== p) (const False)) h || any (go d) sp
@@ -150,7 +149,7 @@ infixl 9 $$, $$*
 
 data TExpr
   = TString
-  | TVar (Var (Either Meta (Index, Name)))
+  | TVar (Var (Either Meta (LName Index)))
   | TForAll Name Kind TExpr
   | TArrow (Maybe Name) Quantity TExpr TExpr
   | TComp (Signature TExpr) TExpr
@@ -163,22 +162,22 @@ data TExpr
 quote :: Level -> Type -> TExpr
 quote d = \case
   VString        -> TString
-  VForAll n t b  -> TForAll n t (quote (succ d) (b (free d n)))
+  VForAll n t b  -> TForAll n t (quote (succ d) (b (free (LName d n))))
   VArrow n q a b -> TArrow n q (quote d a) (quote d b)
   VComp s t      -> TComp (mapSignature (quote d) s) (quote d t)
-  VNe n sp       -> foldl' (&) (TVar (fmap (first (levelToIndex d)) <$> n)) (flip TApp . quote d <$> sp)
+  VNe n sp       -> foldl' (&) (TVar (fmap (fmap (levelToIndex d)) <$> n)) (flip TApp . quote d <$> sp)
 
 eval :: HasCallStack => Subst Type -> Env Type -> TExpr -> Type
 eval subst = go where
   go env = \case
-    TString                    -> VString
-    TVar (Global n)            -> global n
-    TVar (Free (Right (v, n))) -> index env v n
-    TVar (Free (Left m))       -> fromMaybe (metavar m) (lookupMeta m subst)
-    TForAll n t b              -> VForAll n t (\ _T -> go (env |> pvar (n :=: _T)) b)
-    TArrow n q a b             -> VArrow n q (go env a) (go env b)
-    TComp s t                  -> VComp (mapSignature (go env) s) (go env t)
-    TApp  f a                  -> go env f $$  go env a
+    TString               -> VString
+    TVar (Global n)       -> global n
+    TVar (Free (Right n)) -> index env n
+    TVar (Free (Left m))  -> fromMaybe (metavar m) (lookupMeta m subst)
+    TForAll n t b         -> VForAll n t (\ _T -> go (env |> pvar (n :=: _T)) b)
+    TArrow n q a b        -> VArrow n q (go env a) (go env b)
+    TComp s t             -> VComp (mapSignature (go env) s) (go env t)
+    TApp  f a             -> go env f $$  go env a
 
 apply :: HasCallStack => Subst Type -> Env Type -> Type -> Type
 apply subst env = eval subst env . quote (level env)

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -32,7 +32,7 @@ module Facet.Core.Type
 
 import           Control.Effect.Empty
 import           Data.Foldable (foldl')
-import           Data.Function ((&))
+import           Data.Function (on, (&))
 import qualified Data.IntMap as IntMap
 import           Facet.Name
 import           Facet.Snoc
@@ -61,6 +61,9 @@ data Type
   | VArrow (Maybe Name) Quantity Type Type
   | VNe (Var (Either Meta Level)) (Snoc Type)
   | VComp [Interface Type] Type
+
+instance Eq Type where
+  (==) = (==) `on` quote 0
 
 
 global :: RName -> Type

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -165,8 +165,8 @@ quote d = \case
   VComp s t      -> TComp (mapSignature (quote d) s) (quote d t)
   VNe n sp       -> foldl' (&) (TVar (fmap (levelToIndex d) <$> n)) (flip TApp . quote d <$> sp)
 
-eval :: HasCallStack => Subst Type -> Snoc Type -> TExpr -> Type
-eval subst = go where
+eval :: HasCallStack => Subst Type -> Level -> TExpr -> Type
+eval subst d = go (fromList (map free [0..d])) where
   go env = \case
     TString               -> VString
     TVar (Global n)       -> global n
@@ -177,5 +177,5 @@ eval subst = go where
     TComp s t             -> VComp (mapSignature (go env) s) (go env t)
     TApp  f a             -> go env f $$  go env a
 
-apply :: HasCallStack => Subst Type -> Snoc Type -> Type -> Type
-apply subst env = eval subst env . quote (Level (length env))
+apply :: HasCallStack => Subst Type -> Level -> Type -> Type
+apply subst d = eval subst d . quote d

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -58,7 +58,7 @@ data Interface a = Interface RName (Snoc a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 newtype Signature a = Signature { interfaces :: [Interface a] }
-  deriving (Eq, Foldable, Functor, Monoid, Ord, Semigroup, Show, Traversable)
+  deriving (Eq, Foldable, Functor, Monoid, Ord, Semigroup, Show)
 
 singleton :: Interface a -> Signature a
 singleton = Signature . pure

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -111,13 +111,13 @@ unComp = \case
 
 
 data Classifier
-  = SK Kind
-  | ST Type
+  = CK Kind
+  | CT Type
 
 classifierType :: Classifier -> Maybe Type
 classifierType = \case
-  SK _K -> empty
-  ST _T -> pure _T
+  CK _K -> empty
+  CT _T -> pure _T
 
 
 occursIn :: Meta -> Level -> Type -> Bool

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -4,7 +4,9 @@ module Facet.Core.Type
   -- * Types
 , Interface(..)
 , Signature(..)
+, fromInterfaces
 , singleton
+, interfaces
 , mapSignature
 , Type(..)
 , global
@@ -37,6 +39,7 @@ import           Control.Effect.Empty
 import           Data.Foldable (foldl')
 import           Data.Function (on, (&))
 import qualified Data.IntMap as IntMap
+import qualified Data.Set as Set
 import           Facet.Name
 import           Facet.Snoc
 import           Facet.Syntax
@@ -58,14 +61,20 @@ data Kind
 data Interface a = Interface RName (Snoc a)
   deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
-newtype Signature a = Signature { interfaces :: [Interface a] }
+newtype Signature a = Signature { getSignature :: Set.Set (Interface a) }
   deriving (Eq, Foldable, Monoid, Ord, Semigroup, Show)
 
-singleton :: Interface a -> Signature a
-singleton = Signature . pure
+fromInterfaces :: Ord a => [Interface a] -> Signature a
+fromInterfaces = Signature . Set.fromList
 
-mapSignature :: (a -> b) -> Signature a -> Signature b
-mapSignature f = Signature . map (fmap f) . interfaces
+singleton :: Interface a -> Signature a
+singleton = Signature . Set.singleton
+
+interfaces :: Signature a -> [Interface a]
+interfaces = Set.toList . getSignature
+
+mapSignature :: Ord b => (a -> b) -> Signature a -> Signature b
+mapSignature f = Signature . Set.map (fmap f) . getSignature
 
 
 data Type

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -166,7 +166,7 @@ quote d = \case
   VNe n sp       -> foldl' (&) (TVar (fmap (levelToIndex d) <$> n)) (flip TApp . quote d <$> sp)
 
 eval :: HasCallStack => Subst Type -> Level -> TExpr -> Type
-eval subst d = go (fromList (map free [0..d])) where
+eval subst d = go (fromList (map free [0..pred d])) where
   go env = \case
     TString               -> VString
     TVar (Global n)       -> global n

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -112,17 +112,15 @@ subjectType = \case
   ST _T -> pure _T
 
 
-occursIn :: (Var (Either Meta Level) -> Bool) -> Level -> Type -> Bool
+occursIn :: Meta -> Level -> Type -> Bool
 occursIn p = go
   where
   go d = \case
     VForAll _ _ b  -> go (succ d) (b (free d))
     VArrow _ _ a b -> go d a || go d b
-    VComp s t      -> goS d s || go d t
-    VNe h sp       -> p h || any (go d) sp
+    VComp s t      -> any (go d) s || go d t
+    VNe h sp       -> any (either (== p) (const False)) h || any (go d) sp
     VString        -> False
-  goS d (Signature s) = any (goI d) s
-  goI d (Interface h sp) = p (Global h) || any (go d) sp
 
 
 -- Elimination

--- a/src/Facet/Core/Type.hs
+++ b/src/Facet/Core/Type.hs
@@ -65,6 +65,9 @@ data Type
 instance Eq Type where
   (==) = (==) `on` quote 0
 
+instance Ord Type where
+  compare = compare `on` quote 0
+
 
 global :: RName -> Type
 global = var . Global

--- a/src/Facet/Effect/Time.hs
+++ b/src/Facet/Effect/Time.hs
@@ -4,9 +4,6 @@ module Facet.Effect.Time
   now
 , timeWith
 , timeWith_
-, epoch
-, sinceEpochWith
-, eraFrom
 , Time(..)
   -- * Re-exports
 , Algebra
@@ -15,6 +12,7 @@ module Facet.Effect.Time
 ) where
 
 import Control.Algebra
+import Data.Kind (Type)
 
 now :: Has (Time instant) sig m => m instant
 now = send Now
@@ -33,23 +31,5 @@ timeWith_ :: Has (Time instant) sig m => (instant -> instant -> delta) -> m a ->
 timeWith_ with m = with <$> now <* m <*> now
 {-# INLINE timeWith_ #-}
 
-epoch :: Has (Time instant) sig m => m instant
-epoch = send Epoch
-{-# INLINE epoch #-}
-
-sinceEpochWith :: Has (Time instant) sig m => (instant -> instant -> delta) -> m delta
-sinceEpochWith with = do
-  now <- now
-  epoch <- epoch
-  let d = with epoch now
-  d `seq` pure d
-{-# INLINE sinceEpochWith #-}
-
-eraFrom :: Has (Time instant) sig m => instant -> m a -> m a
-eraFrom t m = send (EraFrom t m)
-{-# INLINE eraFrom #-}
-
-data Time instant m k where
-  Now     ::                   Time instant m instant
-  Epoch   ::                   Time instant m instant
-  EraFrom :: instant -> m a -> Time instant m a
+data Time instant (m :: Type -> Type) k where
+  Now :: Time instant m instant

--- a/src/Facet/Effect/Time.hs
+++ b/src/Facet/Effect/Time.hs
@@ -3,6 +3,7 @@ module Facet.Effect.Time
 ( -- * Time effect
   now
 , timeWith
+, timeWith_
 , epoch
 , sinceEpochWith
 , eraFrom
@@ -27,6 +28,10 @@ timeWith with m = do
   let d = with start end
   d `seq` pure (d, a)
 {-# INLINE timeWith #-}
+
+timeWith_ :: Has (Time instant) sig m => (instant -> instant -> delta) -> m a -> m delta
+timeWith_ with m = with <$> now <* m <*> now
+{-# INLINE timeWith_ #-}
 
 epoch :: Has (Time instant) sig m => m instant
 epoch = send Epoch

--- a/src/Facet/Effect/Time/System.hs
+++ b/src/Facet/Effect/Time/System.hs
@@ -3,6 +3,7 @@ module Facet.Effect.Time.System
 ( -- * Time effect
   now
 , timeWith
+, timeWith_
 , time
 , time_
 , Time(..)
@@ -18,7 +19,7 @@ module Facet.Effect.Time.System
 
 import           Data.Fixed
 import           Data.Time.Clock.System
-import           Facet.Effect.Time hiding (now, timeWith)
+import           Facet.Effect.Time hiding (now, timeWith, timeWith_)
 import qualified Facet.Effect.Time as T
 
 now :: Has (Time Instant) sig m => m Instant
@@ -28,6 +29,10 @@ now = T.now
 timeWith :: Has (Time Instant) sig m => (Instant -> Instant -> delta) -> m a -> m (delta, a)
 timeWith = T.timeWith
 {-# INLINE timeWith #-}
+
+timeWith_ :: Has (Time Instant) sig m => (Instant -> Instant -> delta) -> m a -> m delta
+timeWith_ = T.timeWith_
+{-# INLINE timeWith_ #-}
 
 time :: Has (Time Instant) sig m => m a -> m (Duration, a)
 time = timeWith since

--- a/src/Facet/Effect/Time/System.hs
+++ b/src/Facet/Effect/Time/System.hs
@@ -4,6 +4,7 @@ module Facet.Effect.Time.System
   now
 , timeWith
 , time
+, time_
 , epoch
 , sinceEpochWith
 , sinceEpoch
@@ -36,6 +37,10 @@ timeWith = T.timeWith
 time :: Has (Time Instant) sig m => m a -> m (Duration, a)
 time = timeWith since
 {-# INLINE time #-}
+
+time_ :: Has (Time Instant) sig m => m a -> m Duration
+time_ = timeWith_ since
+{-# INLINE time_ #-}
 
 epoch :: Has (Time Instant) sig m => m Instant
 epoch = T.epoch

--- a/src/Facet/Effect/Time/System.hs
+++ b/src/Facet/Effect/Time/System.hs
@@ -5,11 +5,6 @@ module Facet.Effect.Time.System
 , timeWith
 , time
 , time_
-, epoch
-, sinceEpochWith
-, sinceEpoch
-, eraFrom
-, era
 , Time(..)
   -- * Measurements
 , Instant(..)
@@ -23,7 +18,7 @@ module Facet.Effect.Time.System
 
 import           Data.Fixed
 import           Data.Time.Clock.System
-import           Facet.Effect.Time hiding (epoch, eraFrom, now, sinceEpochWith, timeWith)
+import           Facet.Effect.Time hiding (now, timeWith)
 import qualified Facet.Effect.Time as T
 
 now :: Has (Time Instant) sig m => m Instant
@@ -41,28 +36,6 @@ time = timeWith since
 time_ :: Has (Time Instant) sig m => m a -> m Duration
 time_ = timeWith_ since
 {-# INLINE time_ #-}
-
-epoch :: Has (Time Instant) sig m => m Instant
-epoch = T.epoch
-{-# INLINE epoch #-}
-
-sinceEpochWith :: Has (Time Instant) sig m => (Instant -> Instant -> delta) -> m delta
-sinceEpochWith = T.sinceEpochWith
-{-# INLINE sinceEpochWith #-}
-
-sinceEpoch :: Has (Time Instant) sig m => m Duration
-sinceEpoch = sinceEpochWith since
-{-# INLINE sinceEpoch #-}
-
-eraFrom :: Has (Time Instant) sig m => Instant -> m a -> m a
-eraFrom = T.eraFrom
-{-# INLINE eraFrom #-}
-
-era :: Has (Time Instant) sig m => m a -> m a
-era m = do
-  epoch <- now
-  eraFrom epoch m
-{-# INLINE era #-}
 
 
 newtype Instant = Instant { getInstant :: SystemTime }

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -125,8 +125,8 @@ lookupInContext (m:.n)
 
 -- FIXME: probably we should instead look up the effect op globally, then check for membership in the sig
 -- FIXME: return the index in the sig; it’s vital for evaluation of polymorphic effects when there are multiple such
-lookupInSig :: Has (Choose :+: Empty) sig m => QName -> Module -> Graph -> Signature Type -> m (RName :=: Def)
-lookupInSig (m :. n) mod graph = foldMapC (\ (Interface q@(m':.:_) _) -> do
+lookupInSig :: Has (Choose :+: Empty) sig m => QName -> Module -> Graph -> [Signature Type] -> m (RName :=: Def)
+lookupInSig (m :. n) mod graph = foldMapC $ foldMapC (\ (Interface q@(m':.:_) _) -> do
   guard (m == Nil || m == toSnoc m')
   defs <- interfaceScope =<< lookupQ graph mod (toQ q)
   _ :=: d <- lookupScope n defs
@@ -179,7 +179,7 @@ data Err = Err
   , reason    :: ErrReason
   , context   :: Context
   , subst     :: Subst
-  , sig       :: Signature Type
+  , sig       :: [Signature Type]
   , callStack :: CallStack
   }
 
@@ -291,14 +291,14 @@ data StaticContext = StaticContext
 
 data ElabContext = ElabContext
   { context :: Context
-  , sig     :: Signature Type
+  , sig     :: [Signature Type]
   , spans   :: Snoc Span
   }
 
 context_ :: Lens' ElabContext Context
 context_ = lens (\ ElabContext{ context } -> context) (\ e context -> (e :: ElabContext){ context })
 
-sig_ :: Lens' ElabContext (Signature Type)
+sig_ :: Lens' ElabContext [Signature Type]
 sig_ = lens (\ ElabContext{ sig } -> sig) (\ e sig -> (e :: ElabContext){ sig })
 
 spans_ :: Lens' ElabContext (Snoc Span)

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -15,6 +15,7 @@ module Facet.Elab
 , pushSpan
 , Err(..)
 , ErrReason(..)
+, UnifyErr(..)
 , UnifyErrReason(..)
 , err
 , couldNotUnify
@@ -195,10 +196,16 @@ data ErrReason
   | AmbiguousName QName [RName]
   | CouldNotSynthesize
   | ResourceMismatch Name Quantity Quantity
-  | Unify UnifyErrReason (Exp (Either String Classifier)) (Act Classifier)
+  | Unify UnifyErr
   | Hole Name Classifier
   | Invariant String
   | MissingInterface (Interface Type)
+
+data UnifyErr = UnifyErr
+  { reason   :: UnifyErrReason
+  , expected :: Exp (Either String Classifier)
+  , actual   :: Act Classifier
+  }
 
 data UnifyErrReason
   = Mismatch
@@ -211,11 +218,12 @@ applySubst ctx subst r = case r of
   CouldNotSynthesize{} -> r
   ResourceMismatch{}   -> r
   -- NB: not substituting in @r@ because we want to retain the cyclic occurrence (and finitely)
-  Unify r exp act      -> Unify r (fmap roundtripS <$> exp) (roundtripS <$> act)
+  Unify uerr           -> Unify (unifyErr uerr)
   Hole n t             -> Hole n (roundtripS t)
   Invariant{}          -> r
   MissingInterface i   -> MissingInterface (roundtrip <$> i)
   where
+  unifyErr (UnifyErr r exp act) = UnifyErr r (fmap roundtripS <$> exp) (roundtripS <$> act)
   roundtripS = \case
     CK k -> CK k
     CT k -> CT $ roundtrip k
@@ -231,13 +239,13 @@ err reason = do
   throwError $ Err (maybe source (slice source) (peek spans)) (applySubst context subst reason) context subst sig GHC.Stack.callStack
 
 mismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => Exp (Either String Classifier) -> Act Classifier -> m a
-mismatch exp act = withFrozenCallStack $ err $ Unify Mismatch exp act
+mismatch exp act = withFrozenCallStack $ err $ Unify $ UnifyErr Mismatch exp act
 
 couldNotUnify :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => Exp Classifier -> Act Classifier -> m a
 couldNotUnify t1 t2 = withFrozenCallStack $ mismatch (Right <$> t1) t2
 
 occursCheckFailure :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => Meta -> Classifier -> Exp Classifier -> Act Classifier -> m a
-occursCheckFailure m v exp act = withFrozenCallStack $ err $ Unify (Occurs m v) (Right <$> exp) act
+occursCheckFailure m v exp act = withFrozenCallStack $ err $ Unify $ UnifyErr (Occurs m v) (Right <$> exp) act
 
 couldNotSynthesize :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => m a
 couldNotSynthesize = withFrozenCallStack $ err CouldNotSynthesize

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -214,8 +214,8 @@ applySubst ctx subst r = case r of
   where
   d = level ctx
   roundtripS = \case
-    SK k -> SK k
-    ST k -> ST $ roundtrip k
+    CK k -> CK k
+    CT k -> CT $ roundtrip k
   roundtrip = apply subst d
 
 
@@ -277,7 +277,7 @@ assertMatch :: (HasCallStack, Has (Throw Err) sig m) => (Classifier -> Maybe out
 assertMatch pat exp _T = maybe (mismatch (Exp (Left exp)) (Act _T)) pure (pat _T)
 
 assertFunction :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m (Maybe Name ::: (Quantity, Type), Type)
-assertFunction = assertMatch (\case{ ST (VArrow n q t b) -> pure (n ::: (q, t), b) ; _ -> Nothing }) "_ -> _" . ST
+assertFunction = assertMatch (\case{ CT (VArrow n q t b) -> pure (n ::: (q, t), b) ; _ -> Nothing }) "_ -> _" . CT
 
 
 -- Unification

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -119,7 +119,7 @@ resolveC = resolveWith lookupC
 resolveQ :: (HasCallStack, Has (Throw Err) sig m) => QName -> Elab m (RName :=: Def)
 resolveQ = resolveWith lookupD
 
-lookupInContext :: Has (Choose :+: Empty) sig m => QName -> Context -> m (Index, Quantity, Either Kind Type)
+lookupInContext :: Has (Choose :+: Empty) sig m => QName -> Context -> m (Index, Quantity, Classifier)
 lookupInContext (m:.n)
   | m == Nil  = lookupIndex n
   | otherwise = const empty

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -139,12 +139,12 @@ lookupInSig (m :. n) mod graph = foldMapC $ foldMapC (\ (Interface q@(m':.:_) _)
   interfaceScope (_ :=: d) = case d of { DInterface defs _K -> pure defs ; _ -> empty }
 
 
-(|-) :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Pattern Binding -> m a -> m a
-p |- b = do
+(|-) :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => (Quantity, Pattern Binding) -> m a -> m a
+(q, p) |- b = do
   sigma <- asks scale
   d <- depth
-  (u, a) <- censor (`Usage.withoutVars` Vars.singleton d) $ listen $ locally context_ (|> p) b
-  for_ p $ \ (Binding n q _T) -> do
+  (u, a) <- censor (`Usage.withoutVars` Vars.singleton d) $ listen $ locally context_ (|> (q, p)) b
+  for_ p $ \ (Binding n _T) -> do
     let exp = sigma >< q
         act = Usage.lookup d n u
     unless (act `sat` exp)

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -122,7 +122,7 @@ resolveC = resolveWith lookupC
 resolveQ :: (HasCallStack, Has (Throw Err) sig m) => QName -> Elab m (RName :=: Def)
 resolveQ = resolveWith lookupD
 
-lookupInContext :: Has (Choose :+: Empty) sig m => QName -> Context -> m (Index, Name, Quantity, Classifier)
+lookupInContext :: Has (Choose :+: Empty) sig m => QName -> Context -> m (LName Index, Quantity, Classifier)
 lookupInContext (m:.n)
   | m == Nil  = lookupIndex n
   | otherwise = const empty
@@ -146,7 +146,7 @@ lookupInSig (m :. n) mod graph = foldMapC $ foldMapC (\ (Interface q@(m':.:_) _)
   (u, a) <- censor (`Usage.withoutVars` Vars.singleton d) $ listen $ locally context_ (|> (q, p)) b
   for_ p $ \ (n ::: _T) -> do
     let exp = sigma >< q
-        act = Usage.lookup d n u
+        act = Usage.lookup (LName d n) u
     unless (act `sat` exp)
       $ resourceMismatch n exp act
   pure a
@@ -167,10 +167,10 @@ evalTExpr texpr = T.eval <$> get <*> views context_ toEnv <*> pure texpr
 depth :: Has (Reader ElabContext) sig m => m Level
 depth = views context_ level
 
-use :: Has (Reader ElabContext :+: Writer Usage) sig m => Index -> Name -> Quantity -> m ()
-use i n q = do
+use :: Has (Reader ElabContext :+: Writer Usage) sig m => LName Index -> Quantity -> m ()
+use n q = do
   d <- depth
-  tell (Usage.singleton (indexToLevel d i) n q)
+  tell (Usage.singleton (indexToLevel d <$> n) q)
 
 
 -- Errors

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -317,13 +317,6 @@ spans_ :: Lens' ElabContext (Snoc Span)
 spans_ = lens spans (\ e spans -> e{ spans })
 
 
-newtype Exp a = Exp { getExp :: a }
-  deriving (Functor)
-
-newtype Act a = Act { getAct :: a }
-  deriving (Functor)
-
-
 -- Machinery
 
 newtype Elab m a = Elab { runElab :: ReaderC ElabContext (ReaderC StaticContext (WriterC Usage (StateC (Subst Type) m))) a }

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -88,8 +88,8 @@ import           Prelude hiding (span, zipWith)
 -- General
 
 -- FIXME: should we give metas names so we can report holes or pattern variables cleanly?
-meta :: Has (State Subst) sig m => Kind -> m Meta
-meta _T = state (declareMeta _T)
+meta :: Has (State (Subst Type)) sig m => Kind -> m Meta
+meta _T = state (declareMeta @Type _T)
 
 
 instantiate :: Algebra sig m => (a -> TExpr -> a) -> a ::: Type -> Elab m (a ::: Type)
@@ -135,7 +135,7 @@ lookupInSig (m :. n) mod graph = foldMapC $ foldMapC (\ (Interface q@(m':.:_) _)
   interfaceScope (_ :=: d) = case d of { DInterface defs _K -> pure defs ; _ -> empty }
 
 
-(|-) :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err :+: Writer Usage) sig m) => Binding -> m a -> m a
+(|-) :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Binding -> m a -> m a
 Binding n q _T |- b = do
   sigma <- asks scale
   d <- depth
@@ -156,7 +156,7 @@ sat a b
   | otherwise = True
 
 
-evalTExpr :: Has (Reader ElabContext :+: State Subst) sig m => TExpr -> m Type
+evalTExpr :: Has (Reader ElabContext :+: State (Subst Type)) sig m => TExpr -> m Type
 evalTExpr texpr = T.eval <$> get <*> views context_ toEnv <*> pure texpr
 
 depth :: Has (Reader ElabContext) sig m => m Level
@@ -178,7 +178,7 @@ data Err = Err
   { source    :: Source
   , reason    :: ErrReason
   , context   :: Context
-  , subst     :: Subst
+  , subst     :: Subst Type
   , sig       :: [Signature Type]
   , callStack :: CallStack
   }
@@ -199,7 +199,7 @@ data UnifyErrReason
   = Mismatch
   | Occurs Meta Subject
 
-applySubst :: Context -> Subst -> ErrReason -> ErrReason
+applySubst :: Context -> Subst Type -> ErrReason -> ErrReason
 applySubst ctx subst r = case r of
   FreeVariable{}       -> r
   AmbiguousName{}      -> r
@@ -219,35 +219,35 @@ applySubst ctx subst r = case r of
 
 
 -- FIXME: apply the substitution before showing this to the user
-err :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => ErrReason -> m a
+err :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => ErrReason -> m a
 err reason = do
   StaticContext{ source } <- ask
   ElabContext{ context, sig, spans } <- ask
   subst <- get
   throwError $ Err (maybe source (slice source) (peek spans)) (applySubst context subst reason) context subst sig GHC.Stack.callStack
 
-mismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => Exp (Either String Subject) -> Act Subject -> m a
+mismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => Exp (Either String Subject) -> Act Subject -> m a
 mismatch exp act = withFrozenCallStack $ err $ Unify Mismatch exp act
 
-couldNotUnify :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => Exp Subject -> Act Subject -> m a
+couldNotUnify :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => Exp Subject -> Act Subject -> m a
 couldNotUnify t1 t2 = withFrozenCallStack $ mismatch (Right <$> t1) t2
 
-occursCheckFailure :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => Meta -> Subject -> Exp Subject -> Act Subject -> m a
+occursCheckFailure :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => Meta -> Subject -> Exp Subject -> Act Subject -> m a
 occursCheckFailure m v exp act = withFrozenCallStack $ err $ Unify (Occurs m v) (Right <$> exp) act
 
-couldNotSynthesize :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => m a
+couldNotSynthesize :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => m a
 couldNotSynthesize = withFrozenCallStack $ err CouldNotSynthesize
 
-resourceMismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => Name -> Quantity -> Quantity -> m a
+resourceMismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => Name -> Quantity -> Quantity -> m a
 resourceMismatch n exp act = withFrozenCallStack $ err $ ResourceMismatch n exp act
 
-freeVariable :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => QName -> m a
+freeVariable :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => QName -> m a
 freeVariable n = withFrozenCallStack $ err $ FreeVariable n
 
-ambiguousName :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => QName -> [RName] -> m a
+ambiguousName :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => QName -> [RName] -> m a
 ambiguousName n qs = withFrozenCallStack $ err $ AmbiguousName n qs
 
-missingInterface :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err) sig m) => Interface Type -> m a
+missingInterface :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => Interface Type -> m a
 missingInterface i = withFrozenCallStack $ err $ MissingInterface i
 
 
@@ -314,10 +314,10 @@ newtype Act a = Act { getAct :: a }
 
 -- Machinery
 
-newtype Elab m a = Elab { runElab :: ReaderC ElabContext (ReaderC StaticContext (WriterC Usage (StateC Subst m))) a }
-  deriving (Algebra (Reader ElabContext :+: Reader StaticContext :+: Writer Usage :+: State Subst :+: sig), Applicative, Functor, Monad)
+newtype Elab m a = Elab { runElab :: ReaderC ElabContext (ReaderC StaticContext (WriterC Usage (StateC (Subst Type) m))) a }
+  deriving (Algebra (Reader ElabContext :+: Reader StaticContext :+: Writer Usage :+: State (Subst Type) :+: sig), Applicative, Functor, Monad)
 
-elabWith :: Has (Reader Graph :+: Reader Module :+: Reader Source) sig m => Quantity -> (Subst -> a -> m b) -> Elab m a -> m b
+elabWith :: Has (Reader Graph :+: Reader Module :+: Reader Source) sig m => Quantity -> (Subst Type -> a -> m b) -> Elab m a -> m b
 elabWith scale k m = runState k mempty . runWriter (const pure) $ do
   (graph, module', source) <- (,,) <$> ask <*> ask <*> ask
   let stat = StaticContext{ graph, module', source, scale }

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -35,8 +35,6 @@ module Facet.Elab
 , ElabContext(..)
 , context_
 , sig_
-, Exp(..)
-, Act(..)
   -- * Machinery
 , Elab(..)
 , evalTExpr

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -139,12 +139,12 @@ lookupInSig (m :. n) mod graph = foldMapC $ foldMapC (\ (Interface q@(m':.:_) _)
   interfaceScope (_ :=: d) = case d of { DInterface defs _K -> pure defs ; _ -> empty }
 
 
-(|-) :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => (Quantity, Pattern Binding) -> m a -> m a
+(|-) :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => (Quantity, Pattern (Name ::: Classifier)) -> m a -> m a
 (q, p) |- b = do
   sigma <- asks scale
   d <- depth
   (u, a) <- censor (`Usage.withoutVars` Vars.singleton d) $ listen $ locally context_ (|> (q, p)) b
-  for_ p $ \ (Binding n _T) -> do
+  for_ p $ \ (n ::: _T) -> do
     let exp = sigma >< q
         act = Usage.lookup d n u
     unless (act `sat` exp)

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -220,7 +220,6 @@ applySubst ctx subst r = case r of
   roundtrip = apply subst (toEnv ctx)
 
 
--- FIXME: apply the substitution before showing this to the user
 err :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err) sig m) => ErrReason -> m a
 err reason = do
   StaticContext{ source } <- ask

--- a/src/Facet/Elab.hs
+++ b/src/Facet/Elab.hs
@@ -73,6 +73,7 @@ import           Facet.Snoc
 import           Facet.Snoc.NonEmpty (toSnoc)
 import           Facet.Source (Source, slice)
 import           Facet.Span (Span(..))
+import           Facet.Subst
 import           Facet.Syntax
 import           Facet.Usage as Usage
 import           Facet.Vars as Vars
@@ -89,7 +90,7 @@ import           Prelude hiding (span, zipWith)
 
 -- FIXME: should we give metas names so we can report holes or pattern variables cleanly?
 meta :: Has (State (Subst Type)) sig m => Kind -> m Meta
-meta _T = state (declareMeta @Type _T)
+meta _T = state (declareMeta @Type)
 
 
 instantiate :: Algebra sig m => (a -> TExpr -> a) -> a ::: Type -> Elab m (a ::: Type)

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -54,6 +54,7 @@ import           Data.Bool (bool)
 import           Data.Foldable
 import           Data.Functor
 import           Data.Maybe (catMaybes, fromMaybe, listToMaybe)
+import           Data.Monoid (Ap(..), First(..))
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import           Data.Traversable (for, mapAccumL)
@@ -391,7 +392,10 @@ findM :: (Foldable t, Monad m) => (a -> m Bool) -> t a -> m (Maybe a)
 findM p = foldrM (\ a rest -> bool rest (Just a) <$> p a) Nothing
 
 findMaybeM :: (Foldable t, Monad m) => (a -> m (Maybe b)) -> t a -> m (Maybe b)
-findMaybeM p = foldrM (\ a rest -> maybe rest Just <$> p a) Nothing
+findMaybeM p = fmap getFirst . foldMapM (fmap First . p)
+
+foldMapM :: (Foldable t, Applicative m, Monoid b) => (a -> m b) -> t a -> m b
+foldMapM f = getAp . foldMap (Ap . f)
 
 
 -- Judgements

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -59,6 +59,7 @@ import           Data.Text (Text)
 import           Data.Traversable (for, mapAccumL)
 import           Facet.Context (Binding(..), toEnv)
 import           Facet.Core.Module as Module
+import           Facet.Core.Pattern
 import           Facet.Core.Term as E
 import           Facet.Core.Type as T hiding (global)
 import           Facet.Effect.Write

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -355,7 +355,7 @@ assertTacitFunction = assertMatch (\case{ ST (VArrow Nothing q t b) -> pure ((q,
 
 -- | Expect a computation type with effects.
 assertComp :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m (Signature Type, Type)
-assertComp = assertMatch (unComp <=< subjectType) "[_] _" . ST
+assertComp = assertMatch (unComp <=< classifierType) "[_] _" . ST
 
 
 -- Elaboration

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -57,7 +57,7 @@ import           Data.Maybe (catMaybes, fromMaybe, listToMaybe)
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import           Data.Traversable (for, mapAccumL)
-import           Facet.Context (Binding(..), toEnv)
+import           Facet.Context (toEnv)
 import           Facet.Core.Module as Module
 import           Facet.Core.Pattern
 import           Facet.Core.Term as E
@@ -119,7 +119,7 @@ tlam :: (HasCallStack, Has (Throw Err) sig m) => Check m Expr -> Check m Expr
 tlam b = Check $ \ _T -> do
   (n ::: _A, _B) <- assertQuantifier _T
   d <- depth
-  b' <- (zero, pvar (Binding n (CK _A))) |- check (b ::: _B (T.free d n))
+  b' <- (zero, pvar (n ::: CK _A)) |- check (b ::: _B (T.free d n))
   pure $ XTLam b'
 
 lam :: (HasCallStack, Has (Throw Err) sig m) => [(Bind m (Pattern Name), Check m Expr)] -> Check m Expr
@@ -145,7 +145,7 @@ wildcardP :: Bind m (ValuePattern Name)
 wildcardP = Bind $ \ _ _ -> fmap (PWildcard,)
 
 varP :: (HasCallStack, Has (Throw Err) sig m) => Name -> Bind m (ValuePattern Name)
-varP n = Bind $ \ q _A b -> Check $ \ _B -> (PVar n,) <$> ((q, pvar (Binding n (CT (wrap _A)))) |- check (b ::: _B))
+varP n = Bind $ \ q _A b -> Check $ \ _B -> (PVar n,) <$> ((q, pvar (n ::: CT (wrap _A))) |- check (b ::: _B))
   where
   wrap = \case
     VComp sig _A -> VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit")) Nil) (VComp sig _A)
@@ -170,14 +170,14 @@ fieldsP = foldr cons
 allP :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => Name -> Bind m (EffectPattern Name)
 allP n = Bind $ \ q _A b -> Check $ \ _B -> do
   (sig, _T) <- assertComp _A
-  (PAll n,) <$> ((q, pvar (Binding n (CT (VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit"))  Nil) (VComp sig _T))))) |- check (b ::: _B))
+  (PAll n,) <$> ((q, pvar (n ::: CT (VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit"))  Nil) (VComp sig _T)))) |- check (b ::: _B))
 
 effP :: (HasCallStack, Has (Throw Err) sig m) => QName -> [Bind m (ValuePattern Name)] -> Name -> Bind m (Pattern Name)
 effP n ps v = Bind $ \ q _A b -> Check $ \ _B -> do
   StaticContext{ module', graph } <- ask
   (sig, _A') <- assertComp _A
   n' ::: _T <- maybe (freeVariable n) (\ (n :=: _ ::: _T) -> instantiate const (n ::: _T)) (listToMaybe (traverse unDTerm =<< lookupInSig n module' graph [sig]))
-  (ps', b') <- check (bind (fieldsP (Bind (\ q' _A' b -> ([],) <$> Check (\ _B -> (q', pvar (Binding v (CT (VArrow Nothing Many _A' _A)))) |- check (b ::: _B)))) ps ::: (q, _T)) b ::: _B)
+  (ps', b') <- check (bind (fieldsP (Bind (\ q' _A' b -> ([],) <$> Check (\ _B -> (q', pvar (v ::: CT (VArrow Nothing Many _A' _A))) |- check (b ::: _B)))) ps ::: (q, _T)) b ::: _B)
   pure (peff n' (fromList ps') v, b')
 
 
@@ -232,7 +232,7 @@ abstractType :: (HasCallStack, Has (Throw Err) sig m) => Elab m TExpr -> Kind ->
 abstractType body = go
   where
   go = \case
-    KArrow  (Just n) a b -> TForAll n a <$> ((zero, pvar (Binding n (CK a))) |- go b)
+    KArrow  (Just n) a b -> TForAll n a <$> ((zero, pvar (n ::: CK a)) |- go b)
     _                    -> body
 
 abstractTerm :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => (Snoc TExpr -> Snoc Expr -> Expr) -> Check m Expr

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -376,7 +376,7 @@ provide :: Has (Reader ElabContext :+: State Subst) sig m => Signature Type -> m
 provide sig m = do
   subst <- get
   env <- views context_ toEnv
-  locally sig_ (fmap (apply subst env) sig <>) m
+  locally sig_ (mapSignature (apply subst env) sig <>) m
 
 require :: (HasCallStack, Has (Throw Err) sig m) => Signature Type -> Elab m ()
 require req = do

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -44,7 +44,7 @@ module Facet.Elab.Term
 import           Control.Algebra
 import           Control.Carrier.Reader
 import           Control.Carrier.State.Church
-import           Control.Effect.Lens (view, views, (.=))
+import           Control.Effect.Lens (view, (.=))
 import           Control.Effect.Throw
 import           Control.Effect.Writer (censor)
 import           Control.Lens (at, ix)
@@ -57,7 +57,7 @@ import           Data.Maybe (catMaybes, fromMaybe, listToMaybe)
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import           Data.Traversable (for, mapAccumL)
-import           Facet.Context (Binding(..), toEnv)
+import           Facet.Context (Binding(..))
 import           Facet.Core.Module as Module
 import           Facet.Core.Pattern
 import           Facet.Core.Term as E
@@ -377,8 +377,8 @@ withSpanS k (S.Ann s _ a) = mapSynth (pushSpan s) (k a)
 provide :: Has (Reader ElabContext :+: State (Subst Type)) sig m => Signature Type -> m a -> m a
 provide sig m = do
   subst <- get
-  env <- views context_ toEnv
-  locally sig_ (mapSignature (apply subst env) sig :) m
+  d <- depth
+  locally sig_ (mapSignature (apply subst d) sig :) m
 
 require :: (HasCallStack, Has (Throw Err) sig m) => Signature Type -> Elab m ()
 require req = do

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -373,7 +373,7 @@ withSpanC k (S.Ann s _ a) = mapCheck (pushSpan s) (k a)
 withSpanS :: Algebra sig m => (a -> Synth m b) -> S.Ann a -> Synth m b
 withSpanS k (S.Ann s _ a) = mapSynth (pushSpan s) (k a)
 
-provide :: Has (Reader ElabContext :+: State Subst) sig m => Signature Type -> m a -> m a
+provide :: Has (Reader ElabContext :+: State (Subst Type)) sig m => Signature Type -> m a -> m a
 provide sig m = do
   subst <- get
   env <- views context_ toEnv

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -388,10 +388,7 @@ require req = do
     Just _  -> pure ()
 
 findMaybeM :: (Foldable t, Monad m) => (a -> m (Maybe b)) -> t a -> m (Maybe b)
-findMaybeM p = fmap getFirst . foldMapM (fmap First . p)
-
-foldMapM :: (Foldable t, Applicative m, Monoid b) => (a -> m b) -> t a -> m b
-foldMapM f = getAp . foldMap (Ap . f)
+findMaybeM p = getAp . fmap getFirst . foldMap (Ap . fmap First . p)
 
 
 -- Judgements

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -119,7 +119,7 @@ tlam :: (HasCallStack, Has (Throw Err) sig m) => Check m Expr -> Check m Expr
 tlam b = Check $ \ _T -> do
   (n ::: _A, _B) <- assertQuantifier _T
   d <- depth
-  b' <- pvar (Binding n zero (CK _A)) |- check (b ::: _B (T.free d n))
+  b' <- (zero, pvar (Binding n (CK _A))) |- check (b ::: _B (T.free d n))
   pure $ XTLam b'
 
 lam :: (HasCallStack, Has (Throw Err) sig m) => [(Bind m (Pattern Name), Check m Expr)] -> Check m Expr
@@ -145,7 +145,7 @@ wildcardP :: Bind m (ValuePattern Name)
 wildcardP = Bind $ \ _ _ -> fmap (PWildcard,)
 
 varP :: (HasCallStack, Has (Throw Err) sig m) => Name -> Bind m (ValuePattern Name)
-varP n = Bind $ \ q _A b -> Check $ \ _B -> (PVar n,) <$> (pvar (Binding n q (CT (wrap _A))) |- check (b ::: _B))
+varP n = Bind $ \ q _A b -> Check $ \ _B -> (PVar n,) <$> ((q, pvar (Binding n (CT (wrap _A)))) |- check (b ::: _B))
   where
   wrap = \case
     VComp sig _A -> VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit")) Nil) (VComp sig _A)
@@ -170,14 +170,14 @@ fieldsP = foldr cons
 allP :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => Name -> Bind m (EffectPattern Name)
 allP n = Bind $ \ q _A b -> Check $ \ _B -> do
   (sig, _T) <- assertComp _A
-  (PAll n,) <$> (pvar (Binding n q (CT (VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit"))  Nil) (VComp sig _T)))) |- check (b ::: _B))
+  (PAll n,) <$> ((q, pvar (Binding n (CT (VArrow Nothing Many (VNe (Global (NE.FromList ["Data", "Unit"] :.: U "Unit"))  Nil) (VComp sig _T))))) |- check (b ::: _B))
 
 effP :: (HasCallStack, Has (Throw Err) sig m) => QName -> [Bind m (ValuePattern Name)] -> Name -> Bind m (Pattern Name)
 effP n ps v = Bind $ \ q _A b -> Check $ \ _B -> do
   StaticContext{ module', graph } <- ask
   (sig, _A') <- assertComp _A
   n' ::: _T <- maybe (freeVariable n) (\ (n :=: _ ::: _T) -> instantiate const (n ::: _T)) (listToMaybe (traverse unDTerm =<< lookupInSig n module' graph [sig]))
-  (ps', b') <- check (bind (fieldsP (Bind (\ q' _A' b -> ([],) <$> Check (\ _B -> pvar (Binding v q' (CT (VArrow Nothing Many _A' _A))) |- check (b ::: _B)))) ps ::: (q, _T)) b ::: _B)
+  (ps', b') <- check (bind (fieldsP (Bind (\ q' _A' b -> ([],) <$> Check (\ _B -> (q', pvar (Binding v (CT (VArrow Nothing Many _A' _A)))) |- check (b ::: _B)))) ps ::: (q, _T)) b ::: _B)
   pure (peff n' (fromList ps') v, b')
 
 
@@ -232,7 +232,7 @@ abstractType :: (HasCallStack, Has (Throw Err) sig m) => Elab m TExpr -> Kind ->
 abstractType body = go
   where
   go = \case
-    KArrow  (Just n) a b -> TForAll n a <$> (pvar (Binding n zero (CK a)) |- go b)
+    KArrow  (Just n) a b -> TForAll n a <$> ((zero, pvar (Binding n (CK a))) |- go b)
     _                    -> body
 
 abstractTerm :: (HasCallStack, Has (Throw Err :+: Write Warn) sig m) => (Snoc TExpr -> Snoc Expr -> Expr) -> Check m Expr

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -50,7 +50,6 @@ import           Control.Effect.Writer (censor)
 import           Control.Lens (at, ix)
 import           Control.Monad ((<=<))
 import           Data.Bifunctor (first)
-import           Data.Bool (bool)
 import           Data.Foldable
 import           Data.Functor
 import           Data.Maybe (catMaybes, fromMaybe, listToMaybe)
@@ -384,12 +383,9 @@ provide sig m = do
 require :: (HasCallStack, Has (Throw Err) sig m) => Signature Type -> Elab m ()
 require req = do
   prv <- view sig_
-  for_ (interfaces req) $ \ i -> findMaybeM (findM (runEq . eqInterface i) . interfaces) prv >>= \case
+  for_ (interfaces req) $ \ i -> findMaybeM (findMaybeM (runUnifyMaybe . unifyInterface i) . interfaces) prv >>= \case
     Nothing -> missingInterface i
     Just _  -> pure ()
-
-findM :: (Foldable t, Monad m) => (a -> m Bool) -> t a -> m (Maybe a)
-findM p = foldrM (\ a rest -> bool rest (Just a) <$> p a) Nothing
 
 findMaybeM :: (Foldable t, Monad m) => (a -> m (Maybe b)) -> t a -> m (Maybe b)
 findMaybeM p = fmap getFirst . foldMapM (fmap First . p)

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -112,7 +112,7 @@ var n = Synth $ ask >>= \ StaticContext{ module', graph } -> ask >>= \ ElabConte
 
 
 hole :: (HasCallStack, Has (Throw Err) sig m) => Name -> Check m a
-hole n = Check $ \ _T -> withFrozenCallStack $ err $ Hole n (ST _T)
+hole n = Check $ \ _T -> withFrozenCallStack $ err $ Hole n (CT _T)
 
 
 tlam :: (HasCallStack, Has (Throw Err) sig m) => Check m Expr -> Check m Expr
@@ -347,15 +347,15 @@ elabModule (S.Ann _ _ (S.Module mname is os ds)) = execState (Module mname [] os
 -- Errors
 
 assertQuantifier :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m (Name ::: Kind, Type -> Type)
-assertQuantifier = assertMatch (\case{ ST (VForAll n t b) -> pure (n ::: t, b) ; _ -> Nothing }) "{_} -> _" . ST
+assertQuantifier = assertMatch (\case{ CT (VForAll n t b) -> pure (n ::: t, b) ; _ -> Nothing }) "{_} -> _" . CT
 
 -- | Expect a tacit (non-variable-binding) function type.
 assertTacitFunction :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m ((Quantity, Type), Type)
-assertTacitFunction = assertMatch (\case{ ST (VArrow Nothing q t b) -> pure ((q, t), b) ; _ -> Nothing }) "_ -> _" . ST
+assertTacitFunction = assertMatch (\case{ CT (VArrow Nothing q t b) -> pure ((q, t), b) ; _ -> Nothing }) "_ -> _" . CT
 
 -- | Expect a computation type with effects.
 assertComp :: (HasCallStack, Has (Throw Err) sig m) => Type -> Elab m (Signature Type, Type)
-assertComp = assertMatch (unComp <=< classifierType) "[_] _" . ST
+assertComp = assertMatch (unComp <=< classifierType) "[_] _" . CT
 
 
 -- Elaboration

--- a/src/Facet/Elab/Term.hs
+++ b/src/Facet/Elab/Term.hs
@@ -72,6 +72,7 @@ import           Facet.Semiring (Few(..), zero, (><<))
 import           Facet.Snoc
 import           Facet.Snoc.NonEmpty as NE
 import           Facet.Source (Source)
+import           Facet.Subst
 import qualified Facet.Surface as S
 import           Facet.Syntax
 import           Facet.Unify

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -22,7 +22,6 @@ import           Control.Monad (unless)
 import           Data.Bifunctor (first)
 import           Data.Foldable (foldl')
 import           Data.Functor (($>))
-import           Facet.Context
 import           Facet.Core.Module
 import           Facet.Core.Pattern
 import           Facet.Core.Type
@@ -61,7 +60,7 @@ _String = IsType $ pure $ TString ::: KType
 forAll :: (HasCallStack, Has (Throw Err) sig m) => Name ::: IsType m Kind -> IsType m TExpr -> IsType m TExpr
 forAll (n ::: t) b = IsType $ do
   t' <- checkIsType (t ::: KType)
-  b' <- (zero, pvar (Binding n (CK t'))) |- checkIsType (b ::: KType)
+  b' <- (zero, pvar (n ::: CK t')) |- checkIsType (b ::: KType)
   pure $ TForAll n t' b' ::: KType
 
 arrow :: (HasCallStack, Has (Throw Err) sig m) => (a -> b -> c) -> IsType m a -> IsType m b -> IsType m c

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -84,7 +84,7 @@ comp s t = IsType $ do
   s' <- traverse (checkIsType . (::: KInterface)) s
   -- FIXME: polarize types and check that this is a value type being returned
   t' <- checkIsType (t ::: KType)
-  pure $ TComp (Signature s') t' ::: KType
+  pure $ TComp (fromInterfaces s') t' ::: KType
 
 
 synthKind :: (HasCallStack, Has (Throw Err) sig m) => S.Ann S.Kind -> IsType m Kind

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -24,6 +24,7 @@ import           Data.Foldable (foldl')
 import           Data.Functor (($>))
 import           Facet.Context
 import           Facet.Core.Module
+import           Facet.Core.Pattern
 import           Facet.Core.Type
 import           Facet.Elab
 import           Facet.Name
@@ -35,8 +36,8 @@ import           GHC.Stack
 
 tvar :: (HasCallStack, Has (Throw Err) sig m) => QName -> IsType m TExpr
 tvar n = IsType $ views context_ (lookupInContext n) >>= \case
-  [(i, q, CK _K)] -> use i q $> (TVar (Free (Right i)) ::: _K)
-  _                 -> resolveQ n >>= \case
+  [(i, n', q, CK _K)] -> use i n' q $> (TVar (Free (Right (i, n'))) ::: _K)
+  _                   -> resolveQ n >>= \case
     q :=: DData      _ _K -> pure $ TVar (Global q) ::: _K
     q :=: DInterface _ _K -> pure $ TVar (Global q) ::: _K
     _                     -> freeVariable n
@@ -60,7 +61,7 @@ _String = IsType $ pure $ TString ::: KType
 forAll :: (HasCallStack, Has (Throw Err) sig m) => Name ::: IsType m Kind -> IsType m TExpr -> IsType m TExpr
 forAll (n ::: t) b = IsType $ do
   t' <- checkIsType (t ::: KType)
-  b' <- Binding n zero (CK t') |- checkIsType (b ::: KType)
+  b' <- pvar (Binding n zero (CK t')) |- checkIsType (b ::: KType)
   pure $ TForAll n t' b' ::: KType
 
 arrow :: (HasCallStack, Has (Throw Err) sig m) => (a -> b -> c) -> IsType m a -> IsType m b -> IsType m c

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -61,7 +61,7 @@ _String = IsType $ pure $ TString ::: KType
 forAll :: (HasCallStack, Has (Throw Err) sig m) => Name ::: IsType m Kind -> IsType m TExpr -> IsType m TExpr
 forAll (n ::: t) b = IsType $ do
   t' <- checkIsType (t ::: KType)
-  b' <- pvar (Binding n zero (CK t')) |- checkIsType (b ::: KType)
+  b' <- (zero, pvar (Binding n (CK t'))) |- checkIsType (b ::: KType)
   pure $ TForAll n t' b' ::: KType
 
 arrow :: (HasCallStack, Has (Throw Err) sig m) => (a -> b -> c) -> IsType m a -> IsType m b -> IsType m c

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -35,7 +35,7 @@ import           GHC.Stack
 
 tvar :: (HasCallStack, Has (Throw Err) sig m) => QName -> IsType m TExpr
 tvar n = IsType $ views context_ (lookupInContext n) >>= \case
-  [(i, q, Left _K)] -> use i q $> (TVar (Free (Right i)) ::: _K)
+  [(i, q, CK _K)] -> use i q $> (TVar (Free (Right i)) ::: _K)
   _                 -> resolveQ n >>= \case
     q :=: DData      _ _K -> pure $ TVar (Global q) ::: _K
     q :=: DInterface _ _K -> pure $ TVar (Global q) ::: _K
@@ -60,7 +60,7 @@ _String = IsType $ pure $ TString ::: KType
 forAll :: (HasCallStack, Has (Throw Err) sig m) => Name ::: IsType m Kind -> IsType m TExpr -> IsType m TExpr
 forAll (n ::: t) b = IsType $ do
   t' <- checkIsType (t ::: KType)
-  b' <- Binding n zero (Left t') |- checkIsType (b ::: KType)
+  b' <- Binding n zero (CK t') |- checkIsType (b ::: KType)
   pure $ TForAll n t' b' ::: KType
 
 arrow :: (HasCallStack, Has (Throw Err) sig m) => (a -> b -> c) -> IsType m a -> IsType m b -> IsType m c

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -35,8 +35,8 @@ import           GHC.Stack
 
 tvar :: (HasCallStack, Has (Throw Err) sig m) => QName -> IsType m TExpr
 tvar n = IsType $ views context_ (lookupInContext n) >>= \case
-  [(i, n', q, CK _K)] -> use i n' q $> (TVar (Free (Right (i, n'))) ::: _K)
-  _                   -> resolveQ n >>= \case
+  [(n', q, CK _K)] -> use n' q $> (TVar (Free (Right n')) ::: _K)
+  _                -> resolveQ n >>= \case
     q :=: DData      _ _K -> pure $ TVar (Global q) ::: _K
     q :=: DInterface _ _K -> pure $ TVar (Global q) ::: _K
     _                     -> freeVariable n

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -84,7 +84,7 @@ comp s t = IsType $ do
   s' <- traverse (checkIsType . (::: KInterface)) s
   -- FIXME: polarize types and check that this is a value type being returned
   t' <- checkIsType (t ::: KType)
-  pure $ TComp s' t' ::: KType
+  pure $ TComp (Signature s') t' ::: KType
 
 
 synthKind :: (HasCallStack, Has (Throw Err) sig m) => S.Ann S.Kind -> IsType m Kind

--- a/src/Facet/Elab/Type.hs
+++ b/src/Facet/Elab/Type.hs
@@ -118,7 +118,7 @@ synthInterface (S.Ann s _ (S.Interface (S.Ann sh _ h) sp)) = IsType $ pushSpan s
 -- Assertions
 
 assertTypeConstructor :: (HasCallStack, Has (Throw Err) sig m) => Kind -> Elab m (Maybe Name ::: Kind, Kind)
-assertTypeConstructor = assertMatch (\case{ SK (KArrow n t b) -> pure (n ::: t, b) ; _ -> Nothing }) "_ -> _" . SK
+assertTypeConstructor = assertMatch (\case{ CK (KArrow n t b) -> pure (n ::: t, b) ; _ -> Nothing }) "_ -> _" . CK
 
 
 -- Judgements
@@ -126,7 +126,7 @@ assertTypeConstructor = assertMatch (\case{ SK (KArrow n t b) -> pure (n ::: t, 
 checkIsType :: (HasCallStack, Has (Throw Err) sig m) => IsType m a ::: Kind -> Elab m a
 checkIsType (m ::: _K) = do
   a ::: _KA <- isType m
-  a <$ unless (_KA == _K) (couldNotUnify (Exp (SK _K)) (Act (SK _KA)))
+  a <$ unless (_KA == _K) (couldNotUnify (Exp (CK _K)) (Act (CK _KA)))
 
 newtype IsType m a = IsType { isType :: Elab m (a ::: Kind) }
 

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -1,0 +1,2 @@
+module Facet.Env
+() where

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -33,9 +33,7 @@ lookup (Env vs) i n = find (\ (n' :=: v) -> v <$ guard (n == n')) (vs ! getIndex
   find f = foldr ((<|>) . f) Nothing
 
 index :: HasCallStack => Env v -> Index -> Name -> v
-index (Env vs) i n = fromMaybe (error ("Env.index: name (" <> show n <> ") not found")) (find (\ (n' :=: v) -> v <$ guard (n == n')) (vs ! getIndex i))
-  where
-  find f = foldr ((<|>) . f) Nothing
+index env i n = fromMaybe (error ("Env.index: name (" <> show n <> ") not found")) (lookup env i n)
 
 level :: Env v -> Level
 level = Level . length . bindings

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -1,2 +1,9 @@
 module Facet.Env
-() where
+( Env(..)
+) where
+
+import Facet.Name
+import Facet.Snoc
+import Facet.Syntax
+
+newtype Env v = Env { bindings :: Snoc (Name :=: v) }

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -18,7 +18,7 @@ import GHC.Stack
 import Prelude hiding (lookup)
 
 newtype Env v = Env { bindings :: Snoc (Pattern (Name :=: v)) }
-  deriving (Monoid, Semigroup)
+  deriving (Foldable, Functor, Monoid, Semigroup, Traversable)
 
 empty :: Env v
 empty = Env Nil

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -2,6 +2,7 @@ module Facet.Env
 ( Env(..)
 , empty
 , (|>)
+, lookup
 , index
 , level
 ) where
@@ -14,6 +15,7 @@ import Facet.Name
 import Facet.Snoc
 import Facet.Syntax
 import GHC.Stack
+import Prelude hiding (lookup)
 
 newtype Env v = Env { bindings :: Snoc (Pattern (Name :=: v)) }
 
@@ -24,6 +26,11 @@ empty = Env Nil
 Env vs |> v = Env (vs :> v)
 
 infixl 5 |>
+
+lookup :: Env v -> Index -> Name -> Maybe v
+lookup (Env vs) i n = find (\ (n' :=: v) -> v <$ guard (n == n')) (vs ! getIndex i)
+  where
+  find f = foldr ((<|>) . f) Nothing
 
 index :: HasCallStack => Env v -> Index -> Name -> v
 index (Env vs) i n = fromMaybe (error ("Env.index: name (" <> show n <> ") not found")) (find (\ (n' :=: v) -> v <$ guard (n == n')) (vs ! getIndex i))

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -1,5 +1,6 @@
 module Facet.Env
 ( Env(..)
+, (|>)
 ) where
 
 import Facet.Core.Pattern
@@ -8,3 +9,8 @@ import Facet.Snoc
 import Facet.Syntax
 
 newtype Env v = Env { bindings :: Snoc (Pattern (Name :=: v)) }
+
+(|>) :: Env v -> Pattern (Name :=: v) -> Env v
+Env vs |> v = Env (vs :> v)
+
+infixl 5 |>

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -1,5 +1,6 @@
 module Facet.Env
 ( Env(..)
+, empty
 , (|>)
 , index
 , level
@@ -15,6 +16,9 @@ import Facet.Syntax
 import GHC.Stack
 
 newtype Env v = Env { bindings :: Snoc (Pattern (Name :=: v)) }
+
+empty :: Env v
+empty = Env Nil
 
 (|>) :: Env v -> Pattern (Name :=: v) -> Env v
 Env vs |> v = Env (vs :> v)

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -2,8 +2,9 @@ module Facet.Env
 ( Env(..)
 ) where
 
+import Facet.Core.Pattern
 import Facet.Name
 import Facet.Snoc
 import Facet.Syntax
 
-newtype Env v = Env { bindings :: Snoc (Name :=: v) }
+newtype Env v = Env { bindings :: Snoc (Pattern (Name :=: v)) }

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -2,6 +2,7 @@ module Facet.Env
 ( Env(..)
 , (|>)
 , index
+, level
 ) where
 
 import Control.Applicative ((<|>))
@@ -24,3 +25,6 @@ index :: HasCallStack => Env v -> Index -> Name -> v
 index (Env vs) i n = fromMaybe (error ("Env.index: name (" <> show n <> ") not found")) (find (\ (n' :=: v) -> v <$ guard (n == n')) (vs ! getIndex i))
   where
   find f = foldr ((<|>) . f) Nothing
+
+level :: Env v -> Level
+level = Level . length . bindings

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -18,6 +18,7 @@ import GHC.Stack
 import Prelude hiding (lookup)
 
 newtype Env v = Env { bindings :: Snoc (Pattern (Name :=: v)) }
+  deriving (Monoid, Semigroup)
 
 empty :: Env v
 empty = Env Nil

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -28,13 +28,13 @@ Env vs |> v = Env (vs :> v)
 
 infixl 5 |>
 
-lookup :: Env v -> Index -> Name -> Maybe v
-lookup (Env vs) i n = find (\ (n' :=: v) -> v <$ guard (n == n')) (vs ! getIndex i)
+lookup :: Env v -> LName Index -> Maybe v
+lookup (Env vs) (LName i n) = find (\ (n' :=: v) -> v <$ guard (n == n')) (vs ! getIndex i)
   where
   find f = foldr ((<|>) . f) Nothing
 
-index :: HasCallStack => Env v -> Index -> Name -> v
-index env i n = fromMaybe (error ("Env.index: name (" <> show n <> ") not found")) (lookup env i n)
+index :: HasCallStack => Env v -> LName Index -> v
+index env n = fromMaybe (error ("Env.index: name (" <> show n <> ") not found")) (lookup env n)
 
 level :: Env v -> Level
 level = Level . length . bindings

--- a/src/Facet/Env.hs
+++ b/src/Facet/Env.hs
@@ -1,12 +1,17 @@
 module Facet.Env
 ( Env(..)
 , (|>)
+, index
 ) where
 
+import Control.Applicative ((<|>))
+import Control.Monad (guard)
+import Data.Maybe (fromMaybe)
 import Facet.Core.Pattern
 import Facet.Name
 import Facet.Snoc
 import Facet.Syntax
+import GHC.Stack
 
 newtype Env v = Env { bindings :: Snoc (Pattern (Name :=: v)) }
 
@@ -14,3 +19,8 @@ newtype Env v = Env { bindings :: Snoc (Pattern (Name :=: v)) }
 Env vs |> v = Env (vs :> v)
 
 infixl 5 |>
+
+index :: HasCallStack => Env v -> Index -> Name -> v
+index (Env vs) i n = fromMaybe (error ("Env.index: name (" <> show n <> ") not found")) (find (\ (n' :=: v) -> v <$ guard (n == n')) (vs ! getIndex i))
+  where
+  find f = foldr ((<|>) . f) Nothing

--- a/src/Facet/Eval.hs
+++ b/src/Facet/Eval.hs
@@ -24,6 +24,7 @@ import Data.Function
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Facet.Core.Module
+import Facet.Core.Pattern
 import Facet.Core.Term
 import Facet.Core.Type (TExpr)
 import Facet.Graph

--- a/src/Facet/Name.hs
+++ b/src/Facet/Name.hs
@@ -92,7 +92,7 @@ toQ (m :.: n) = toSnoc m :. n
 
 -- | Local names, consisting of a 'Level' or 'Index' to a pattern in an 'Env' or 'Context' and a 'Name' bound by said pattern.
 data LName v = LName v Name
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Foldable, Functor, Ord, Show, Traversable)
 
 
 -- | Declaration names; a choice of expression, constructor, term, or operator names.

--- a/src/Facet/Name.hs
+++ b/src/Facet/Name.hs
@@ -11,6 +11,7 @@ module Facet.Name
 , QName(..)
 , RName(..)
 , toQ
+, LName(..)
 , Name(..)
 , Assoc(..)
 , Op(..)
@@ -87,6 +88,10 @@ instance P.Pretty RName where
 -- | Weaken an 'RName' to a 'QName'. This is primarily used for performing lookups in the graph starting from an 'RName' where the stronger structure is not required.
 toQ :: RName -> QName
 toQ (m :.: n) = toSnoc m :. n
+
+
+data LName v = LName v Name
+  deriving (Eq, Ord, Show)
 
 
 -- | Declaration names; a choice of expression, constructor, term, or operator names.

--- a/src/Facet/Name.hs
+++ b/src/Facet/Name.hs
@@ -90,6 +90,7 @@ toQ :: RName -> QName
 toQ (m :.: n) = toSnoc m :. n
 
 
+-- | Local names, consisting of a 'Level' or 'Index' to a pattern in an 'Env' or 'Context' and a 'Name' bound by said pattern.
 data LName v = LName v Name
   deriving (Eq, Ord, Show)
 

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -36,7 +36,7 @@ rethrowElabErrors opts = L.runThrow rethrow
     where
     (_, _, printCtx, ctx) = foldl' combine (0, empty, Nil, Nil) (elems context)
     subst' = map (\ (m :=: v ::: _T) -> getPrint (ann (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v ::: printKind printCtx _T))) (metas subst)
-    sig' = getPrint . printInterface opts printCtx . fmap (apply subst (toEnv context)) <$> interfaces sig
+    sig' = getPrint . printInterface opts printCtx . fmap (apply subst (toEnv context)) <$> (interfaces =<< sig)
     combine (d, env, print, ctx) (Binding n m _T) =
       let n' = intro n d
           roundtrip = apply subst (toEnv env)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -12,6 +12,7 @@ import           Facet.Context
 import           Facet.Core.Type (Classifier(..), apply, free, interfaces, metavar)
 import           Facet.Elab as Elab
 import qualified Facet.Env as Env
+import           Facet.Name (LName(..))
 import           Facet.Notice as Notice hiding (level)
 import           Facet.Pretty
 import           Facet.Print as Print
@@ -45,7 +46,7 @@ rethrowElabErrors opts = L.runThrow rethrow
             CK _K -> printKind print _K
             CT _T -> printType opts print (roundtrip _T)))
       in  ( succ d
-          , env Env.|> ((\ (n ::: _T) -> n :=: free d n) <$> p)
+          , env Env.|> ((\ (n ::: _T) -> n :=: free (LName d n)) <$> p)
           , print Env.|> ((\ (n ::: _) -> n :=: intro n d) <$> p)
           , ctx :> getPrint (printPattern opts (binding <$> p)) )
   mult m = if

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -9,7 +9,7 @@ import           Data.Semigroup (stimes)
 import qualified Facet.Carrier.Throw.Inject as L
 import qualified Facet.Carrier.Write.Inject as L
 import           Facet.Context
-import           Facet.Core.Type (apply, interfaces, metas, metavar)
+import           Facet.Core.Type (apply, interfaces, metavar)
 import           Facet.Elab as Elab
 import           Facet.Notice as Notice
 import           Facet.Pretty
@@ -17,6 +17,7 @@ import           Facet.Print as Print
 import           Facet.Semiring (Few(..), one, zero)
 import           Facet.Snoc
 import           Facet.Style
+import           Facet.Subst (metas)
 import           Facet.Syntax
 import           GHC.Stack
 import           Prelude hiding (unlines)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -9,7 +9,7 @@ import           Data.Semigroup (stimes)
 import qualified Facet.Carrier.Throw.Inject as L
 import qualified Facet.Carrier.Write.Inject as L
 import           Facet.Context
-import           Facet.Core.Type (apply, interfaces, metavar)
+import           Facet.Core.Type (Classifier(..), apply, interfaces, metavar)
 import           Facet.Elab as Elab
 import           Facet.Notice as Notice hiding (level)
 import           Facet.Pretty
@@ -44,7 +44,9 @@ rethrowElabErrors opts = L.runThrow rethrow
       in  ( succ d
           , env |> Binding n m _T
           , print :> n'
-          , ctx :> getPrint (ann (n' ::: mult m (either (printKind print) (printType opts print . roundtrip) _T))) )
+          , ctx :> getPrint (ann (n' ::: mult m (case _T of
+            CK _K -> printKind print _K
+            CT _T -> printType opts print (roundtrip _T)))) )
   mult m = if
     | m == zero -> (pretty "0" <+>)
     | m == one  -> (pretty "1" <+>)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -9,7 +9,7 @@ import           Data.Semigroup (stimes)
 import qualified Facet.Carrier.Throw.Inject as L
 import qualified Facet.Carrier.Write.Inject as L
 import           Facet.Context
-import           Facet.Core.Type (apply, metas, metavar)
+import           Facet.Core.Type (apply, interfaces, metas, metavar)
 import           Facet.Elab as Elab
 import           Facet.Notice as Notice
 import           Facet.Pretty
@@ -36,7 +36,7 @@ rethrowElabErrors opts = L.runThrow rethrow
     where
     (_, _, printCtx, ctx) = foldl' combine (0, empty, Nil, Nil) (elems context)
     subst' = map (\ (m :=: v ::: _T) -> getPrint (ann (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v ::: printKind printCtx _T))) (metas subst)
-    sig' = getPrint . printInterface opts printCtx . fmap (apply subst (toEnv context)) <$> sig
+    sig' = getPrint . printInterface opts printCtx . fmap (apply subst (toEnv context)) <$> interfaces sig
     combine (d, env, print, ctx) (Binding n m _T) =
       let n' = intro n d
           roundtrip = apply subst (toEnv env)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -35,7 +35,7 @@ rethrowElabErrors opts = L.runThrow rethrow
     ]
     where
     (_, _, printCtx, ctx) = foldl' combine (0, empty, Nil, Nil) (elems context)
-    subst' = map (\ (m :=: v ::: _T) -> getPrint (ann (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v ::: printKind printCtx _T))) (metas subst)
+    subst' = map (\ (m :=: v) -> getPrint (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v)) (metas subst)
     sig' = getPrint . printInterface opts printCtx . fmap (apply subst (toEnv context)) <$> (interfaces =<< sig)
     combine (d, env, print, ctx) (Binding n m _T) =
       let n' = intro n d

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -35,14 +35,13 @@ rethrowElabErrors opts = L.runThrow rethrow
     , pretty (prettyCallStack callStack)
     ]
     where
-    (_, _, printCtx, ctx) = foldl' combine (0, empty, Nil, Nil) (elems context)
+    (_, printCtx, ctx) = foldl' combine (0, Nil, Nil) (elems context)
     subst' = map (\ (m :=: v) -> getPrint (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v)) (metas subst)
     sig' = getPrint . printInterface opts printCtx . fmap (apply subst (level context)) <$> (interfaces =<< sig)
-    combine (d, env, print, ctx) (Binding n m _T) =
+    combine (d, print, ctx) (Binding n m _T) =
       let n' = intro n d
-          roundtrip = apply subst (level env)
+          roundtrip = apply subst d
       in  ( succ d
-          , env |> Binding n m _T
           , print :> n'
           , ctx :> getPrint (ann (n' ::: mult m (case _T of
             CK _K -> printKind print _K

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -11,7 +11,7 @@ import qualified Facet.Carrier.Write.Inject as L
 import           Facet.Context
 import           Facet.Core.Type (apply, interfaces, metavar)
 import           Facet.Elab as Elab
-import           Facet.Notice as Notice
+import           Facet.Notice as Notice hiding (level)
 import           Facet.Pretty
 import           Facet.Print as Print
 import           Facet.Semiring (Few(..), one, zero)
@@ -37,10 +37,10 @@ rethrowElabErrors opts = L.runThrow rethrow
     where
     (_, _, printCtx, ctx) = foldl' combine (0, empty, Nil, Nil) (elems context)
     subst' = map (\ (m :=: v) -> getPrint (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v)) (metas subst)
-    sig' = getPrint . printInterface opts printCtx . fmap (apply subst (toEnv context)) <$> (interfaces =<< sig)
+    sig' = getPrint . printInterface opts printCtx . fmap (apply subst (level context)) <$> (interfaces =<< sig)
     combine (d, env, print, ctx) (Binding n m _T) =
       let n' = intro n d
-          roundtrip = apply subst (toEnv env)
+          roundtrip = apply subst (level env)
       in  ( succ d
           , env |> Binding n m _T
           , print :> n'

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -27,8 +27,8 @@ import           Silkscreen
 
 -- Elaboration
 
-rethrowElabErrors :: Options -> L.ThrowC (Notice (Doc Style)) Err m a -> m a
-rethrowElabErrors opts = L.runThrow rethrow
+rethrowElabErrors :: Applicative m => Options -> L.ThrowC (Notice (Doc Style)) Err m a -> m a
+rethrowElabErrors opts = L.runThrow (pure . rethrow)
   where
   rethrow Err{ source, reason, context, subst, sig, callStack } = Notice.Notice (Just Error) [source] (printErrReason opts printCtx reason)
     [ nest 2 (pretty "Context" <\> concatWith (<\>) ctx)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -68,7 +68,7 @@ printErrReason opts ctx = group . \case
       Zero -> pretty "0"
       One  -> pretty "1"
       Many -> pretty "arbitrarily many"
-  Unify r (Exp exp) (Act act) -> reason r
+  Unify (UnifyErr r (Exp exp) (Act act)) -> reason r
     <> hardline <> pretty "expected:" <> print exp'
     <> hardline <> pretty "  actual:" <> print act'
     where

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -39,14 +39,14 @@ rethrowElabErrors opts = L.runThrow rethrow
     (_, _, printCtx, ctx) = foldl' combine (0, Env.empty, Env.empty, Nil) (elems context)
     subst' = map (\ (m :=: v) -> getPrint (Print.meta m <+> pretty '=' <+> maybe (pretty '?') (printType opts printCtx) v)) (metas subst)
     sig' = getPrint . printInterface opts printCtx . fmap (apply subst (toEnv context)) <$> (interfaces =<< sig)
-    combine (d, env, print, ctx) p =
+    combine (d, env, print, ctx) (m, p) =
       let roundtrip = apply subst env
-          binding (Binding n m _T) = ann (intro n d ::: mult m (case _T of
+          binding (Binding n _T) = ann (intro n d ::: mult m (case _T of
             CK _K -> printKind print _K
             CT _T -> printType opts print (roundtrip _T)))
       in  ( succ d
-          , env Env.|> ((\ (Binding n _ _T) -> n :=: free d n) <$> p)
-          , print Env.|> ((\ (Binding n _ _) -> n :=: intro n d) <$> p)
+          , env Env.|> ((\ (Binding n _T) -> n :=: free d n) <$> p)
+          , print Env.|> ((\ (Binding n _) -> n :=: intro n d) <$> p)
           , ctx :> getPrint (printPattern opts (binding <$> p)) )
   mult m = if
     | m == zero -> (pretty "0" <+>)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -41,12 +41,12 @@ rethrowElabErrors opts = L.runThrow rethrow
     sig' = getPrint . printInterface opts printCtx . fmap (apply subst (toEnv context)) <$> (interfaces =<< sig)
     combine (d, env, print, ctx) (m, p) =
       let roundtrip = apply subst env
-          binding (Binding n _T) = ann (intro n d ::: mult m (case _T of
+          binding (n ::: _T) = ann (intro n d ::: mult m (case _T of
             CK _K -> printKind print _K
             CT _T -> printType opts print (roundtrip _T)))
       in  ( succ d
-          , env Env.|> ((\ (Binding n _T) -> n :=: free d n) <$> p)
-          , print Env.|> ((\ (Binding n _) -> n :=: intro n d) <$> p)
+          , env Env.|> ((\ (n ::: _T) -> n :=: free d n) <$> p)
+          , print Env.|> ((\ (n ::: _) -> n :=: intro n d) <$> p)
           , ctx :> getPrint (printPattern opts (binding <$> p)) )
   mult m = if
     | m == zero -> (pretty "0" <+>)

--- a/src/Facet/Notice/Elab.hs
+++ b/src/Facet/Notice/Elab.hs
@@ -68,7 +68,7 @@ printErrReason opts ctx = group . \case
       Zero -> pretty "0"
       One  -> pretty "1"
       Many -> pretty "arbitrarily many"
-  Unify (UnifyErr r (Exp exp) (Act act)) -> reason r
+  Unify r (Exp exp) (Act act) -> reason r
     <> hardline <> pretty "expected:" <> print exp'
     <> hardline <> pretty "  actual:" <> print act'
     where

--- a/src/Facet/Notice/Parser.hs
+++ b/src/Facet/Notice/Parser.hs
@@ -15,8 +15,8 @@ import           Silkscreen
 
 -- Parsing
 
-rethrowParseErrors :: L.ThrowC (Notice (Doc e)) (Source, Parse.Err) m a -> m a
-rethrowParseErrors = L.runThrow (uncurry errToNotice)
+rethrowParseErrors :: Applicative m => L.ThrowC (Notice (Doc e)) (Source, Parse.Err) m a -> m a
+rethrowParseErrors = L.runThrow (pure . uncurry errToNotice)
 
 
 errToNotice :: Source -> Parse.Err -> Notice (Doc a)

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -22,6 +22,7 @@ module Facet.Print
 , printInterface
 , printTExpr
 , printExpr
+, printPattern
 , printModule
   -- * Misc
 , intro

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -35,6 +35,7 @@ import           Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import           Data.Traversable (mapAccumL)
 import qualified Facet.Core.Module as C
+import           Facet.Core.Pattern
 import qualified Facet.Core.Term as C
 import qualified Facet.Core.Type as C
 import qualified Facet.Core.Type as CT
@@ -209,18 +210,18 @@ printExpr opts@Options{ rname, instantiation } = go
   binding env p f = let ((_, env'), p') = mapAccumL (\ (d, env) n -> let v = local n d in ((succ d, env :> v), v)) (Name.Level (length env), env) p in f env' p'
   clause env (p, b) = binding env p $ \ env' p' -> printPattern opts p' <+> arrow <+> go env' b
 
-printPattern :: Options -> C.Pattern Print -> Print
+printPattern :: Options -> Pattern Print -> Print
 printPattern Options{ rname } = \case
-  C.PVal p -> vpat p
-  C.PEff p -> epat p
+  PVal p -> vpat p
+  PEff p -> epat p
   where
   vpat = \case
-    C.PWildcard -> pretty '_'
-    C.PVar n    -> n
-    C.PCon n ps -> parens (hsep (annotate Con (rname n):map vpat (toList ps)))
+    PWildcard -> pretty '_'
+    PVar n    -> n
+    PCon n ps -> parens (hsep (annotate Con (rname n):map vpat (toList ps)))
   epat = \case
-    C.PAll n     -> n
-    C.POp q ps k -> brackets (hsep (pretty q : map vpat (toList ps)) <+> semi <+> k)
+    PAll n     -> n
+    POp q ps k -> brackets (hsep (pretty q : map vpat (toList ps)) <+> semi <+> k)
 
 printModule :: C.Module -> Print
 printModule (C.Module mname is _ ds) = module_

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -149,8 +149,8 @@ suppressInstantiation = const
 
 printSubject :: Options -> Snoc Print -> C.Classifier -> Print
 printSubject opts env = \case
-  C.SK k -> printKind env k
-  C.ST t -> printType opts env t
+  C.CK k -> printKind env k
+  C.CT t -> printType opts env t
 
 printKind :: Snoc Print -> C.Kind -> Print
 printKind env = \case

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -147,7 +147,7 @@ suppressInstantiation = const
 
 -- Core printers
 
-printSubject :: Options -> Snoc Print -> C.Subject -> Print
+printSubject :: Options -> Snoc Print -> C.Classifier -> Print
 printSubject opts env = \case
   C.SK k -> printKind env k
   C.ST t -> printType opts env t

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -207,7 +207,13 @@ printExpr opts@Options{ rname, instantiation } = go
     C.XString s       -> annotate Lit $ pretty (show s)
   qvar = group . setPrec Var . rname
   binding env p f = let ((_, env'), p') = mapAccumL (\ (d, env) n -> let v = local n d in ((succ d, env :> v), v)) (Name.Level (length env), env) p in f env' p'
-  clause env (p, b) = binding env p $ \ env' p' -> pat p' <+> arrow <+> go env' b
+  clause env (p, b) = binding env p $ \ env' p' -> printPattern opts p' <+> arrow <+> go env' b
+
+printPattern :: Options -> C.Pattern Print -> Print
+printPattern Options{ rname } = \case
+  C.PVal p -> vpat p
+  C.PEff p -> epat p
+  where
   vpat = \case
     C.PWildcard -> pretty '_'
     C.PVar n    -> n
@@ -215,9 +221,6 @@ printExpr opts@Options{ rname, instantiation } = go
   epat = \case
     C.PAll n     -> n
     C.POp q ps k -> brackets (hsep (pretty q : map vpat (toList ps)) <+> semi <+> k)
-  pat = \case
-    C.PVal p -> vpat p
-    C.PEff p -> epat p
 
 printModule :: C.Module -> Print
 printModule (C.Module mname is _ ds) = module_

--- a/src/Facet/Print.hs
+++ b/src/Facet/Print.hs
@@ -177,13 +177,12 @@ printTExpr opts@Options{ rname } = go
     C.TForAll      n    t b -> braces (ann (intro n d ::: printKind env t)) --> go (env :> intro n d) b
     C.TArrow Nothing  q a b -> mult q (go env a) --> go env b
     C.TArrow (Just n) q a b -> parens (ann (intro n d ::: mult q (go env a))) --> go env b
-    C.TComp [] t            -> go env t
-    C.TComp s t             -> sig s <+> go env t
+    C.TComp s t             -> if s == mempty then go env t else sig s <+> go env t
     C.TApp f a              -> group (go env f) $$ group (go env a)
     C.TString               -> annotate Type $ pretty "String"
     where
     d = Name.Level (length env)
-    sig s = brackets (commaSep (map (interface env) s))
+    sig s = brackets (commaSep (map (interface env) (C.interfaces s)))
   interface = printInterfaceWith printTExpr opts
   mult q = if
     | q == zero -> (pretty '0' <+>)

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -198,7 +198,7 @@ showType e = Action $ do
   outputDocLn (getPrint (ann (printExpr opts Nil e ::: printType opts Nil _T)))
 
 showEval e = Action $ do
-  e' ::: _T <- runElab $ Elab.elabSynthTerm $ locally Elab.sig_ (T.singleton (T.Interface (["Effect", "Console"]:.:U "Output") Nil) <>) $ Elab.synth (Elab.synthExpr e)
+  e' ::: _T <- runElab $ Elab.elabSynthTerm $ locally Elab.sig_ (T.singleton (T.Interface (["Effect", "Console"]:.:U "Output") Nil) :) $ Elab.synth (Elab.synthExpr e)
   e'' <- runElab $ runEvalMain e'
   opts <- get
   outputDocLn (getPrint (ann (printExpr opts Nil e'' ::: printType opts Nil _T)))

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -198,7 +198,7 @@ showType e = Action $ do
   outputDocLn (getPrint (ann (printExpr opts Nil e ::: printType opts Nil _T)))
 
 showEval e = Action $ do
-  e' ::: _T <- runElab $ Elab.elabSynthTerm $ locally Elab.sig_ (T.Interface (["Effect", "Console"]:.:U "Output") Nil:) $ Elab.synth (Elab.synthExpr e)
+  e' ::: _T <- runElab $ Elab.elabSynthTerm $ locally Elab.sig_ (T.singleton (T.Interface (["Effect", "Console"]:.:U "Output") Nil) <>) $ Elab.synth (Elab.synthExpr e)
   e'' <- runElab $ runEvalMain e'
   opts <- get
   outputDocLn (getPrint (ann (printExpr opts Nil e'' ::: printType opts Nil _T)))

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -195,16 +195,16 @@ showType, showEval :: S.Ann S.Expr -> Action
 showType e = Action $ do
   e ::: _T <- runElab $ Elab.elabSynthTerm (Elab.synth (Elab.synthExpr e))
   opts <- get
-  outputDocLn (getPrint (ann (printExpr opts Nil e ::: printType opts Nil _T)))
+  outputDocLn (getPrint (ann (printExpr opts mempty e ::: printType opts mempty _T)))
 
 showEval e = Action $ do
   e' ::: _T <- runElab $ Elab.elabSynthTerm $ locally Elab.sig_ (T.singleton (T.Interface (["Effect", "Console"]:.:U "Output") Nil) :) $ Elab.synth (Elab.synthExpr e)
   e'' <- runElab $ runEvalMain e'
   opts <- get
-  outputDocLn (getPrint (ann (printExpr opts Nil e'' ::: printType opts Nil _T)))
+  outputDocLn (getPrint (ann (printExpr opts mempty e'' ::: printType opts mempty _T)))
 
 runEvalMain :: (Has (Error (Notice.Notice (Doc Style)) :+: Output :+: Reader Graph :+: Reader Module :+: State Options) sig m, MonadFail m) => Expr -> m Expr
-runEvalMain e = runEval (E.quoteV 0 =<< eval Nil hdl e) pure
+runEvalMain e = runEval (E.quoteV 0 =<< eval mempty hdl e) pure
   where
   hdl = [(write, Handler handle)]
   write = fromList ["Effect", "Console"] :.: U "write"
@@ -218,7 +218,7 @@ showKind :: S.Ann S.Type -> Action
 showKind _T = Action $ do
   _T ::: _K <- runElab $ Elab.elabSynthType (Elab.isType (Elab.synthType _T))
   opts <- get
-  outputDocLn (getPrint (ann (printType opts Nil _T ::: printKind Nil _K)))
+  outputDocLn (getPrint (ann (printType opts mempty _T ::: printKind mempty _K)))
 
 
 helpDoc :: Doc Style

--- a/src/Facet/REPL.hs
+++ b/src/Facet/REPL.hs
@@ -116,7 +116,7 @@ loop = do
       graph <- use (target_.modules_)
       targets <- use (target_.targets_)
       let ops = foldMap (\ name -> lookupM name graph >>= maybe [] pure . snd >>= map (\ (op, assoc) -> (name, op, assoc)) . operators) (toList targets)
-      action <- rethrowParseErrors @Style (runParserWithSource src (runFacet (map (\ (n, a, b) -> makeOperator (n, a, b)) ops) commandParser))
+      action <- rethrowParseErrors @_ @Style (runParserWithSource src (runFacet (map (\ (n, a, b) -> makeOperator (n, a, b)) ops) commandParser))
       runReader src $ runAction action
     Nothing  -> pure ()
   loop

--- a/src/Facet/Subst.hs
+++ b/src/Facet/Subst.hs
@@ -1,2 +1,35 @@
 module Facet.Subst
-() where
+( -- * Substitution
+  Subst(..)
+, insert
+, lookupMeta
+, solveMeta
+, declareMeta
+, metas
+) where
+
+import           Control.Monad (join)
+import qualified Data.IntMap as IntMap
+import           Facet.Name
+import           Facet.Syntax
+
+-- Substitution
+
+newtype Subst t = Subst (IntMap.IntMap (Maybe t))
+  deriving (Monoid, Semigroup)
+
+insert :: Meta -> Maybe t -> Subst t -> Subst t
+insert (Meta i) t (Subst metas) = Subst (IntMap.insert i t metas)
+
+lookupMeta :: Meta -> Subst t -> Maybe t
+lookupMeta (Meta i) (Subst metas) = join (IntMap.lookup i metas)
+
+solveMeta :: Meta -> t -> Subst t -> Subst t
+solveMeta (Meta i) t (Subst metas) = Subst (IntMap.update (const (Just (Just t))) i metas)
+
+declareMeta :: Subst t -> (Subst t, Meta)
+declareMeta (Subst metas) = (Subst (IntMap.insert v Nothing metas), Meta v) where
+  v = maybe 0 (succ . fst . fst) (IntMap.maxViewWithKey metas)
+
+metas :: Subst t -> [Meta :=: Maybe t]
+metas (Subst metas) = map (\ (k, v) -> Meta k :=: v) (IntMap.toList metas)

--- a/src/Facet/Subst.hs
+++ b/src/Facet/Subst.hs
@@ -1,0 +1,2 @@
+module Facet.Subst
+() where

--- a/src/Facet/Syntax.hs
+++ b/src/Facet/Syntax.hs
@@ -9,6 +9,9 @@ module Facet.Syntax
   -- * Decomposition
 , splitl
 , splitr
+  -- * Assertion data
+, Exp(..)
+, Act(..)
 ) where
 
 import Data.Bifoldable
@@ -95,3 +98,12 @@ splitr un = go id
   go as t = case un t of
     Just (a, t') -> go (as . (a:)) t'
     Nothing      -> (as [], t)
+
+
+-- Assertion data
+
+newtype Exp a = Exp { getExp :: a }
+  deriving (Functor)
+
+newtype Act a = Act { getAct :: a }
+  deriving (Functor)

--- a/src/Facet/Syntax.hs
+++ b/src/Facet/Syntax.hs
@@ -3,6 +3,7 @@ module Facet.Syntax
 , tm
 , ty
 , (:=:)(..)
+, nm, def
   -- * Variables
 , Var(..)
   -- * Decomposition
@@ -63,6 +64,12 @@ instance Bifunctor (:=:) where
 
 instance Bitraversable (:=:) where
   bitraverse f g (a :=: b) = (:=:) <$> f a <*> g b
+
+nm :: a :=: b -> a
+nm (a :=: _) = a
+
+def :: a :=: b -> b
+def (_ :=: b) = b
 
 
 -- Variables

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -44,7 +44,7 @@ occurs v t = ask >>= \ (t1 :=: t2) -> occursCheckFailure v (ST t) t1 t2
 
 unifyType :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State Subst :+: Throw Err :+: Writer Usage) sig m) => Type -> Type -> m Type
 unifyType = curry $ \case
-  (VComp s1 t1, VComp s2 t2)                           -> VComp <$> unifySpine unifyInterface s1 s2 <*> unifyType t1 t2
+  (VComp s1 t1, VComp s2 t2)                           -> VComp . Signature <$> unifySpine unifyInterface (interfaces s1) (interfaces s2) <*> unifyType t1 t2
   (VComp s1 t1, t2)                                    -> VComp s1 <$> unifyType t1 t2
   (t1, VComp s2 t2)                                    -> VComp s2 <$> unifyType t1 t2
   (VNe (Free (Left v1)) Nil, VNe (Free (Left v2)) Nil) -> flexFlex v1 v2
@@ -100,7 +100,7 @@ runEq = execEmpty
 
 eqType :: (HasCallStack, Has (Empty :+: Reader ElabContext :+: Reader StaticContext :+: State Subst :+: Throw Err :+: Writer Usage) sig m) => Type -> Type -> m ()
 eqType = curry $ \case
-  (VComp s1 t1, VComp s2 t2)           -> eqSpine eqInterface s1 s2 *> eqType t1 t2
+  (VComp s1 t1, VComp s2 t2)           -> eqSpine eqInterface (interfaces s1) (interfaces s2) *> eqType t1 t2
   (VComp _ t1, t2)                     -> eqType t1 t2
   (t1, VComp _ t2)                     -> eqType t1 t2
   (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> (Binding n zero (Left t2) |- eqType (b1 (free d)) (b2 (free d)))

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -36,7 +36,7 @@ unify :: (HasCallStack, Has (Throw Err) sig m) => Exp Type -> Act Type -> Elab m
 unify t1 t2 = runUnify t1 t2 (unifyType (getExp t1) (getAct t2))
 
 runUnify :: Has (Throw Err) sig m => Exp Type -> Act Type -> ErrorC (WithCallStack UnifyErrReason) (Elab m) a -> Elab m a
-runUnify t1 t2 = runError (withCallStack (\ r -> err (Unify (UnifyErr r (Right . CT <$> t1) (CT <$> t2))))) pure
+runUnify t1 t2 = runError (withCallStack (\ r -> err (Unify r (Right . CT <$> t1) (CT <$> t2)))) pure
 
 mismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: State (Subst Type) :+: Throw Err :+: Throw (WithCallStack UnifyErrReason) :+: Writer Usage) sig m) => m a
 mismatch   = withFrozenCallStack $ throwError $ WithCallStack GHC.Stack.callStack Mismatch

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -35,13 +35,13 @@ unify :: (HasCallStack, Has (Throw Err) sig m) => Exp Type -> Act Type -> Elab m
 unify t1 t2 = runUnify t1 t2 (unifyType (getExp t1) (getAct t2))
 
 runUnify :: Exp Type -> Act Type -> ReaderC (Exp Classifier :=: Act Classifier) m a -> m a
-runUnify t1 t2 = runReader (fmap ST t1 :=: fmap ST t2)
+runUnify t1 t2 = runReader (fmap CT t1 :=: fmap CT t2)
 
 mismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => m a
 mismatch   = ask >>= \ (t1 :=: t2) -> couldNotUnify               t1 t2
 
 occurs :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Meta -> Type -> m a
-occurs v t = ask >>= \ (t1 :=: t2) -> occursCheckFailure v (ST t) t1 t2
+occurs v t = ask >>= \ (t1 :=: t2) -> occursCheckFailure v (CT t) t1 t2
 
 unifyType :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Type -> Type -> m Type
 unifyType = curry $ \case

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -6,6 +6,7 @@ module Facet.Unify
 , UnifyErrReason(..)
 , unify
 , runUnifyMaybe
+, unifyType
   -- * Equating
 , runEq
 , eqInterface

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -51,7 +51,7 @@ unifyType = curry $ \case
   (VNe (Free (Left v1)) Nil, VNe (Free (Left v2)) Nil) -> flexFlex v1 v2
   (VNe (Free (Left v1)) Nil, t2)                       -> solve v1 t2
   (t1, VNe (Free (Left v2)) Nil)                       -> solve v2 t1
-  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> (Binding n zero (Left t2) |- unifyType (b1 (free d)) (b2 (free d)))
+  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> (Binding n zero (CK t2) |- unifyType (b1 (free d)) (b2 (free d)))
   (VForAll{}, _)                                       -> mismatch
   (VArrow _ _ a1 b1, VArrow n q a2 b2)                 -> VArrow n q <$> unifyType a1 a2 <*> unifyType b1 b2
   (VArrow{}, _)                                        -> mismatch
@@ -104,7 +104,7 @@ eqType = curry $ \case
   (VComp s1 t1, VComp s2 t2)           -> eqSpine eqInterface (interfaces s1) (interfaces s2) *> eqType t1 t2
   (VComp _ t1, t2)                     -> eqType t1 t2
   (t1, VComp _ t2)                     -> eqType t1 t2
-  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> (Binding n zero (Left t2) |- eqType (b1 (free d)) (b2 (free d)))
+  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> (Binding n zero (CK t2) |- eqType (b1 (free d)) (b2 (free d)))
   (VForAll{}, _)                       -> empty
   (VArrow _ _ a1 b1, VArrow _ _ a2 b2) -> eqType a1 a2 *> eqType b1 b2
   (VArrow{}, _)                        -> empty

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -23,6 +23,7 @@ import Facet.Name
 import Facet.Semialign
 import Facet.Semiring
 import Facet.Snoc
+import Facet.Subst
 import Facet.Syntax
 import Facet.Usage
 import GHC.Stack

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -77,9 +77,9 @@ flexFlex :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: 
 flexFlex v1 v2
   | v1 == v2  = pure (metavar v2)
   | otherwise = gets (\ s -> (lookupMeta v1 s, lookupMeta v2 s)) >>= \case
-    (Just t1, Just t2) -> unifyType (tm t1) (tm t2)
-    (Just t1, Nothing) -> unifyType (metavar v2) (tm t1)
-    (Nothing, Just t2) -> unifyType (metavar v1) (tm t2)
+    (Just t1, Just t2) -> unifyType t1 t2
+    (Just t1, Nothing) -> unifyType (metavar v2) t1
+    (Nothing, Just t2) -> unifyType (metavar v1) t2
     (Nothing, Nothing) -> solve v1 (metavar v2)
 
 solve :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State Subst :+: Throw Err :+: Writer Usage) sig m) => Meta -> Type -> m Type
@@ -89,8 +89,8 @@ solve v t = do
     occurs v t
   else
     gets (lookupMeta v) >>= \case
-      Nothing          -> t <$ modify (solveMeta v t)
-      Just (t' ::: _T) -> unifyType t' t >>= \ t'' -> t'' <$ modify (solveMeta v t'')
+      Nothing -> t <$ modify (solveMeta v t)
+      Just t' -> unifyType t' t >>= \ t'' -> t'' <$ modify (solveMeta v t'')
 
 
 -- Equating

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -51,7 +51,7 @@ unifyType = curry $ \case
   (VNe (Free (Left v1)) Nil, VNe (Free (Left v2)) Nil) -> flexFlex v1 v2
   (VNe (Free (Left v1)) Nil, t2)                       -> solve v1 t2
   (t1, VNe (Free (Left v2)) Nil)                       -> solve v2 t1
-  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> ((zero, pvar (n ::: CK t2)) |- unifyType (b1 (free d n)) (b2 (free d n)))
+  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> ((zero, pvar (n ::: CK t2)) |- unifyType (b1 (free (LName d n))) (b2 (free (LName d n))))
   (VForAll{}, _)                                       -> mismatch
   (VArrow _ _ a1 b1, VArrow n q a2 b2)                 -> VArrow n q <$> unifyType a1 a2 <*> unifyType b1 b2
   (VArrow{}, _)                                        -> mismatch
@@ -104,7 +104,7 @@ eqType = curry $ \case
   (VComp s1 t1, VComp s2 t2)           -> eqSpine eqInterface (interfaces s1) (interfaces s2) *> eqType t1 t2
   (VComp _ t1, t2)                     -> eqType t1 t2
   (t1, VComp _ t2)                     -> eqType t1 t2
-  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> ((zero, pvar (n ::: CK t2)) |- eqType (b1 (free d n)) (b2 (free d n)))
+  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> ((zero, pvar (n ::: CK t2)) |- eqType (b1 (free (LName d n))) (b2 (free (LName d n))))
   (VForAll{}, _)                       -> empty
   (VArrow _ _ a1 b1, VArrow _ _ a2 b2) -> eqType a1 a2 *> eqType b1 b2
   (VArrow{}, _)                        -> empty

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -52,7 +52,7 @@ unifyType = curry $ \case
   (VNe (Free (Left v1)) Nil, VNe (Free (Left v2)) Nil) -> flexFlex v1 v2
   (VNe (Free (Left v1)) Nil, t2)                       -> solve v1 t2
   (t1, VNe (Free (Left v2)) Nil)                       -> solve v2 t1
-  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> (pvar (Binding n zero (CK t2)) |- unifyType (b1 (free d n)) (b2 (free d n)))
+  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> ((zero, pvar (Binding n (CK t2))) |- unifyType (b1 (free d n)) (b2 (free d n)))
   (VForAll{}, _)                                       -> mismatch
   (VArrow _ _ a1 b1, VArrow n q a2 b2)                 -> VArrow n q <$> unifyType a1 a2 <*> unifyType b1 b2
   (VArrow{}, _)                                        -> mismatch
@@ -105,7 +105,7 @@ eqType = curry $ \case
   (VComp s1 t1, VComp s2 t2)           -> eqSpine eqInterface (interfaces s1) (interfaces s2) *> eqType t1 t2
   (VComp _ t1, t2)                     -> eqType t1 t2
   (t1, VComp _ t2)                     -> eqType t1 t2
-  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> (pvar (Binding n zero (CK t2)) |- eqType (b1 (free d n)) (b2 (free d n)))
+  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> ((zero, pvar (Binding n (CK t2))) |- eqType (b1 (free d n)) (b2 (free d n)))
   (VForAll{}, _)                       -> empty
   (VArrow _ _ a1 b1, VArrow _ _ a2 b2) -> eqType a1 a2 *> eqType b1 b2
   (VArrow{}, _)                        -> empty

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -17,6 +17,7 @@ import Control.Effect.Throw
 import Control.Effect.Writer
 import Control.Monad (unless)
 import Facet.Context hiding (empty)
+import Facet.Core.Pattern
 import Facet.Core.Type
 import Facet.Elab
 import Facet.Name
@@ -51,7 +52,7 @@ unifyType = curry $ \case
   (VNe (Free (Left v1)) Nil, VNe (Free (Left v2)) Nil) -> flexFlex v1 v2
   (VNe (Free (Left v1)) Nil, t2)                       -> solve v1 t2
   (t1, VNe (Free (Left v2)) Nil)                       -> solve v2 t1
-  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> (Binding n zero (CK t2) |- unifyType (b1 (free d)) (b2 (free d)))
+  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> (pvar (Binding n zero (CK t2)) |- unifyType (b1 (free d n)) (b2 (free d n)))
   (VForAll{}, _)                                       -> mismatch
   (VArrow _ _ a1 b1, VArrow n q a2 b2)                 -> VArrow n q <$> unifyType a1 a2 <*> unifyType b1 b2
   (VArrow{}, _)                                        -> mismatch
@@ -104,7 +105,7 @@ eqType = curry $ \case
   (VComp s1 t1, VComp s2 t2)           -> eqSpine eqInterface (interfaces s1) (interfaces s2) *> eqType t1 t2
   (VComp _ t1, t2)                     -> eqType t1 t2
   (t1, VComp _ t2)                     -> eqType t1 t2
-  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> (Binding n zero (CK t2) |- eqType (b1 (free d)) (b2 (free d)))
+  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> (pvar (Binding n zero (CK t2)) |- eqType (b1 (free d n)) (b2 (free d n)))
   (VForAll{}, _)                       -> empty
   (VArrow _ _ a1 b1, VArrow _ _ a2 b2) -> eqType a1 a2 *> eqType b1 b2
   (VArrow{}, _)                        -> empty

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -7,6 +7,7 @@ module Facet.Unify
 , unify
 , runUnifyMaybe
 , unifyType
+, unifyInterface
   -- * Equating
 , runEq
 , eqInterface

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -44,7 +44,7 @@ occurs v t = ask >>= \ (t1 :=: t2) -> occursCheckFailure v (ST t) t1 t2
 
 unifyType :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State Subst :+: Throw Err :+: Writer Usage) sig m) => Type -> Type -> m Type
 unifyType = curry $ \case
-  (VComp s1 t1, VComp s2 t2)                           -> VComp . Signature <$> unifySpine unifyInterface (interfaces s1) (interfaces s2) <*> unifyType t1 t2
+  (VComp s1 t1, VComp s2 t2)                           -> VComp . fromInterfaces <$> unifySpine unifyInterface (interfaces s1) (interfaces s2) <*> unifyType t1 t2
   (VComp s1 t1, t2)                                    -> VComp s1 <$> unifyType t1 t2
   (t1, VComp s2 t2)                                    -> VComp s2 <$> unifyType t1 t2
   (VNe (Free (Left v1)) Nil, VNe (Free (Left v2)) Nil) -> flexFlex v1 v2

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -16,7 +16,6 @@ import Control.Effect.Sum
 import Control.Effect.Throw
 import Control.Effect.Writer
 import Control.Monad (unless)
-import Facet.Context hiding (empty)
 import Facet.Core.Pattern
 import Facet.Core.Type
 import Facet.Elab
@@ -52,7 +51,7 @@ unifyType = curry $ \case
   (VNe (Free (Left v1)) Nil, VNe (Free (Left v2)) Nil) -> flexFlex v1 v2
   (VNe (Free (Left v1)) Nil, t2)                       -> solve v1 t2
   (t1, VNe (Free (Left v2)) Nil)                       -> solve v2 t1
-  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> ((zero, pvar (Binding n (CK t2))) |- unifyType (b1 (free d n)) (b2 (free d n)))
+  (VForAll _ t1 b1, VForAll n t2 b2)                   -> depth >>= \ d -> evalTExpr =<< mkForAll d n <$> unifyKind t1 t2 <*> ((zero, pvar (n ::: CK t2)) |- unifyType (b1 (free d n)) (b2 (free d n)))
   (VForAll{}, _)                                       -> mismatch
   (VArrow _ _ a1 b1, VArrow n q a2 b2)                 -> VArrow n q <$> unifyType a1 a2 <*> unifyType b1 b2
   (VArrow{}, _)                                        -> mismatch
@@ -105,7 +104,7 @@ eqType = curry $ \case
   (VComp s1 t1, VComp s2 t2)           -> eqSpine eqInterface (interfaces s1) (interfaces s2) *> eqType t1 t2
   (VComp _ t1, t2)                     -> eqType t1 t2
   (t1, VComp _ t2)                     -> eqType t1 t2
-  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> ((zero, pvar (Binding n (CK t2))) |- eqType (b1 (free d n)) (b2 (free d n)))
+  (VForAll _ t1 b1, VForAll n t2 b2)   -> depth >>= \ d -> guard (t1 == t2) *> ((zero, pvar (n ::: CK t2)) |- eqType (b1 (free d n)) (b2 (free d n)))
   (VForAll{}, _)                       -> empty
   (VArrow _ _ a1 b1, VArrow _ _ a2 b2) -> eqType a1 a2 *> eqType b1 b2
   (VArrow{}, _)                        -> empty

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -85,7 +85,7 @@ flexFlex v1 v2
 solve :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State Subst :+: Throw Err :+: Writer Usage) sig m) => Meta -> Type -> m Type
 solve v t = do
   d <- depth
-  if occursIn (== Free (Left v)) d t then
+  if occursIn v d t then
     occurs v t
   else
     gets (lookupMeta v) >>= \case

--- a/src/Facet/Unify.hs
+++ b/src/Facet/Unify.hs
@@ -34,16 +34,16 @@ import GHC.Stack
 unify :: (HasCallStack, Has (Throw Err) sig m) => Exp Type -> Act Type -> Elab m Type
 unify t1 t2 = runUnify t1 t2 (unifyType (getExp t1) (getAct t2))
 
-runUnify :: Exp Type -> Act Type -> ReaderC (Exp Subject :=: Act Subject) m a -> m a
+runUnify :: Exp Type -> Act Type -> ReaderC (Exp Classifier :=: Act Classifier) m a -> m a
 runUnify t1 t2 = runReader (fmap ST t1 :=: fmap ST t2)
 
-mismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => m a
+mismatch :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => m a
 mismatch   = ask >>= \ (t1 :=: t2) -> couldNotUnify               t1 t2
 
-occurs :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Meta -> Type -> m a
+occurs :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Meta -> Type -> m a
 occurs v t = ask >>= \ (t1 :=: t2) -> occursCheckFailure v (ST t) t1 t2
 
-unifyType :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Type -> Type -> m Type
+unifyType :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Type -> Type -> m Type
 unifyType = curry $ \case
   (VComp s1 t1, VComp s2 t2)                           -> VComp . fromInterfaces <$> unifySpine unifyInterface (interfaces s1) (interfaces s2) <*> unifyType t1 t2
   (VComp s1 t1, t2)                                    -> VComp s1 <$> unifyType t1 t2
@@ -62,19 +62,19 @@ unifyType = curry $ \case
   where
   mkForAll d n k b = TForAll n k (quote (succ d) b)
 
-unifyKind :: Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m => Kind -> Kind -> m Kind
+unifyKind :: Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m => Kind -> Kind -> m Kind
 unifyKind k1 k2 = if k1 == k2 then pure k2 else mismatch
 
-unifyVar :: (Eq a, Eq b, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Var (Either a b) -> Var (Either a b) -> m (Var (Either a b))
+unifyVar :: (Eq a, Eq b, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Var (Either a b) -> Var (Either a b) -> m (Var (Either a b))
 unifyVar v1 v2 = if v1 == v2 then pure v2 else mismatch
 
-unifyInterface :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Interface Type -> Interface Type -> m (Interface Type)
+unifyInterface :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Interface Type -> Interface Type -> m (Interface Type)
 unifyInterface (Interface h1 sp1) (Interface h2 sp2) = Interface h2 <$ unless (h1 == h2) mismatch <*> unifySpine unifyType sp1 sp2
 
-unifySpine :: (Traversable t, Zip t, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => (a -> b -> m c) -> t a -> t b -> m (t c)
+unifySpine :: (Traversable t, Zip t, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => (a -> b -> m c) -> t a -> t b -> m (t c)
 unifySpine f sp1 sp2 = unless (length sp1 == length sp2) mismatch >> zipWithM f sp1 sp2
 
-flexFlex :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Meta -> Meta -> m Type
+flexFlex :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Meta -> Meta -> m Type
 flexFlex v1 v2
   | v1 == v2  = pure (metavar v2)
   | otherwise = gets (\ s -> (lookupMeta v1 s, lookupMeta v2 s)) >>= \case
@@ -83,7 +83,7 @@ flexFlex v1 v2
     (Nothing, Just t2) -> unifyType (metavar v1) t2
     (Nothing, Nothing) -> solve v1 (metavar v2)
 
-solve :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Subject :=: Act Subject) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Meta -> Type -> m Type
+solve :: (HasCallStack, Has (Reader ElabContext :+: Reader StaticContext :+: Reader (Exp Classifier :=: Act Classifier) :+: State (Subst Type) :+: Throw Err :+: Writer Usage) sig m) => Meta -> Type -> m Type
 solve v t = do
   d <- depth
   if occursIn v d t then

--- a/src/Facet/Usage.hs
+++ b/src/Facet/Usage.hs
@@ -35,11 +35,11 @@ instance Monoid Usage where
 instance LeftModule Quantity Usage where
   q ><< Usage a = Usage (fmap (q ><) <$> a)
 
-singleton :: Level -> Name -> Quantity -> Usage
-singleton (Level i) n q = Usage (IntMap.singleton i (Map.singleton n q))
+singleton :: LName Level -> Quantity -> Usage
+singleton (LName (Level i) n) q = Usage (IntMap.singleton i (Map.singleton n q))
 
-lookup :: Level -> Name -> Usage -> Quantity
-lookup (Level i) n (Usage a) = fromMaybe zero (Map.lookup n =<< IntMap.lookup i a)
+lookup :: LName Level -> Usage -> Quantity
+lookup (LName (Level i) n) (Usage a) = fromMaybe zero (Map.lookup n =<< IntMap.lookup i a)
 
 restrict :: Usage -> Vars.Vars -> Usage
 restrict (Usage u) (Vars.Vars v) = Usage (u `IntMap.restrictKeys` v)

--- a/src/Facet/Usage.hs
+++ b/src/Facet/Usage.hs
@@ -10,6 +10,7 @@ module Facet.Usage
 ) where
 
 import qualified Data.IntMap as IntMap
+import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe)
 import           Facet.Name
 import           Facet.Semiring
@@ -23,7 +24,7 @@ type Quantity = Few
 
 -- Usage
 
-newtype Usage = Usage (IntMap.IntMap Quantity)
+newtype Usage = Usage (IntMap.IntMap (Map.Map Name Quantity))
 
 instance Semigroup Usage where
   Usage a <> Usage b = Usage (IntMap.unionWith (<>) a b)
@@ -32,13 +33,13 @@ instance Monoid Usage where
   mempty = Usage mempty
 
 instance LeftModule Quantity Usage where
-  q ><< Usage a = Usage ((q ><) <$> a)
+  q ><< Usage a = Usage (fmap (q ><) <$> a)
 
-singleton :: Level -> Quantity -> Usage
-singleton (Level i) q = Usage (IntMap.singleton i q)
+singleton :: Level -> Name -> Quantity -> Usage
+singleton (Level i) n q = Usage (IntMap.singleton i (Map.singleton n q))
 
-lookup :: Level -> Usage -> Quantity
-lookup (Level i) (Usage a) = fromMaybe zero (IntMap.lookup i a)
+lookup :: Level -> Name -> Usage -> Quantity
+lookup (Level i) n (Usage a) = fromMaybe zero (Map.lookup n =<< IntMap.lookup i a)
 
 restrict :: Usage -> Vars.Vars -> Usage
 restrict (Usage u) (Vars.Vars v) = Usage (u `IntMap.restrictKeys` v)

--- a/test/Facet/Core/Type/Test.hs
+++ b/test/Facet/Core/Type/Test.hs
@@ -15,5 +15,5 @@ tests :: IO Bool
 tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
-  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right 0))) (TComp [] (TVar (Free (Right 0)))))
+  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right 0))) (TComp mempty (TVar (Free (Right 0)))))
   quote 0 (eval mempty Nil init) === init

--- a/test/Facet/Core/Type/Test.hs
+++ b/test/Facet/Core/Type/Test.hs
@@ -15,5 +15,5 @@ tests :: IO Bool
 tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
-  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right (LName 0 (U "x"))))) (TComp mempty (TVar (Free (Right (LName 0 (U "x")))))))
+  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right (LName 0 (U "A"))))) (TComp mempty (TVar (Free (Right (LName 0 (U "A")))))))
   quote 0 (eval mempty empty init) === init

--- a/test/Facet/Core/Type/Test.hs
+++ b/test/Facet/Core/Type/Test.hs
@@ -5,6 +5,7 @@ module Facet.Core.Type.Test
 ) where
 
 import Facet.Core.Type
+import Facet.Env
 import Facet.Name
 import Facet.Semiring
 import Facet.Syntax
@@ -14,5 +15,5 @@ tests :: IO Bool
 tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
-  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right 0))) (TComp mempty (TVar (Free (Right 0)))))
-  quote 0 (eval mempty 0 init) === init
+  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right (0, "x")))) (TComp mempty (TVar (Free (Right (0, "x"))))))
+  quote 0 (eval mempty empty init) === init

--- a/test/Facet/Core/Type/Test.hs
+++ b/test/Facet/Core/Type/Test.hs
@@ -7,7 +7,6 @@ module Facet.Core.Type.Test
 import Facet.Core.Type
 import Facet.Name
 import Facet.Semiring
-import Facet.Snoc
 import Facet.Syntax
 import Hedgehog hiding (Var, eval)
 
@@ -16,4 +15,4 @@ tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
   let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right 0))) (TComp mempty (TVar (Free (Right 0)))))
-  quote 0 (eval mempty Nil init) === init
+  quote 0 (eval mempty 0 init) === init

--- a/test/Facet/Core/Type/Test.hs
+++ b/test/Facet/Core/Type/Test.hs
@@ -15,5 +15,5 @@ tests :: IO Bool
 tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
-  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right (0, "x")))) (TComp mempty (TVar (Free (Right (0, "x"))))))
+  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right (LName 0 "x")))) (TComp mempty (TVar (Free (Right (LName 0 "x"))))))
   quote 0 (eval mempty empty init) === init

--- a/test/Facet/Core/Type/Test.hs
+++ b/test/Facet/Core/Type/Test.hs
@@ -15,5 +15,5 @@ tests :: IO Bool
 tests = checkParallel $$(discover)
 
 prop_quotation_inverse = property $ do
-  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right (LName 0 "x")))) (TComp mempty (TVar (Free (Right (LName 0 "x"))))))
+  let init = TForAll (U "A") KType (TArrow (Just (U "x")) Many (TVar (Free (Right (LName 0 (U "x"))))) (TComp mempty (TVar (Free (Right (LName 0 (U "x")))))))
   quote 0 (eval mempty empty init) === init


### PR DESCRIPTION
This PR changes contexts & environments from snoc lists of types/values to snoc lists of patterns, themselves (in general) trees of types/values. This requires a commensurate enrichment of variables, which we currently represent as `LName`s, which pair indices/levels and names within the pattern at the indicated position in the context.

There’s clearly a great deal of similarity between `Context` and the new `Env` type which could perhaps be resolved by extending `Env` to wrap pointers in a functor, or pair them with a value. That’s left as future work, however.