### PR TITLE
Bump the ghc version for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["8.10.3"]
+        ghc: ["8.10.4"]
         cabal: ["3.2.0.0"]
 
     steps:

--- a/facet.cabal
+++ b/facet.cabal
@@ -14,7 +14,7 @@ copyright:           2020 Rob Rix
 category:            Language
 
 tested-with:
-  GHC == 8.10.3
+  GHC == 8.10.4
 
 common common
   default-language: Haskell2010


### PR DESCRIPTION
Apparently 8.10.3 isn’t available any more, or something.